### PR TITLE
Category level

### DIFF
--- a/sqlalchemy_mptt/events.py
+++ b/sqlalchemy_mptt/events.py
@@ -409,7 +409,7 @@ class TreesManager(object):
                 session.expire(parent, ['left', 'right'])
                 parent = self.get_parent_value(parent)
             else:
-                session.expire(instance, ['tree_id', ])
+                session.expire(instance, ['tree_id', 'level'])
 
     @staticmethod
     def get_parent_value(instance):

--- a/sqlalchemy_mptt/tests/tree_testing_base.py
+++ b/sqlalchemy_mptt/tests/tree_testing_base.py
@@ -1722,6 +1722,7 @@ class TreeTestingMixin(object):
         node.move_after('1')
         self.session.flush()
         self.assertEqual(node.tree_id, 2)
+        self.assertEqual(node.level, 1)
         self.assertEqual(node.parent_id, None)
 
         children = self.session.query(self.model)\


### PR DESCRIPTION
In relation to issue #33 
`level` should also be expired.
