### PR TITLE
Migrates tree_id from an `Integer` to `Unicode(32)`

### DIFF
--- a/sqlalchemy_mptt/events.py
+++ b/sqlalchemy_mptt/events.py
@@ -296,17 +296,7 @@ def mptt_before_update(mapper, connection, instance):
                         parent_tree_id, parent_level, node_level, left_sibling,
                         table_pk)
     else:
-        # if insert after
-        if left_sibling_tree_id or left_sibling_tree_id == 0:
-            tree_id = str(uuid.uuid4())
-            connection.execute(
-                table.update(table.c.tree_id > left_sibling_tree_id)
-                .values(tree_id=str(uuid.uuid4()))
-            )
-        # if just insert
-        else:
-            tree_id = str(uuid.uuid4())
-
+        tree_id = str(uuid.uuid4())
         connection.execute(
             table.update(table_pk.in_(subtree))
             .values(

--- a/sqlalchemy_mptt/events.py
+++ b/sqlalchemy_mptt/events.py
@@ -297,12 +297,11 @@ def mptt_before_update(mapper, connection, instance):
                         table_pk)
     else:
         # if insert after
-        # TODO: what case is this?  In the GUID world, this tree_id update mech won't work
         if left_sibling_tree_id or left_sibling_tree_id == 0:
-            tree_id = left_sibling_tree_id + 1
+            tree_id = str(uuid.uuid4())
             connection.execute(
                 table.update(table.c.tree_id > left_sibling_tree_id)
-                .values(tree_id=table.c.tree_id + 1)
+                .values(tree_id=str(uuid.uuid4()))
             )
         # if just insert
         else:

--- a/sqlalchemy_mptt/events.py
+++ b/sqlalchemy_mptt/events.py
@@ -15,6 +15,7 @@ from sqlalchemy import and_, case, event, inspection, select
 from sqlalchemy.orm import object_session
 from sqlalchemy.orm.base import NO_VALUE
 from sqlalchemy.sql import func
+import uuid
 
 
 def _insert_subtree(table, connection, node_size,
@@ -73,8 +74,7 @@ def mptt_before_insert(mapper, connection, instance):
         instance.left = 1
         instance.right = 2
         instance.level = 1
-        tree_id = connection.scalar(
-            select([func.max(table.c.tree_id) + 1])) or 1
+        tree_id = str(uuid.uuid4())
         instance.tree_id = tree_id
     else:
         (parent_pos_left,
@@ -197,7 +197,7 @@ def mptt_before_update(mapper, connection, instance):
                             'is_parent': False}
         # if move_before to top level
         elif not right_sibling_parent:
-            left_sibling_tree_id = right_sibling_tree_id - 1
+            left_sibling_tree_id = str(uuid.uuid4())
 
     # if placed after a particular node
     if hasattr(instance, 'mptt_move_after'):
@@ -297,6 +297,7 @@ def mptt_before_update(mapper, connection, instance):
                         table_pk)
     else:
         # if insert after
+        # TODO: what case is this?  In the GUID world, this tree_id update mech won't work
         if left_sibling_tree_id or left_sibling_tree_id == 0:
             tree_id = left_sibling_tree_id + 1
             connection.execute(
@@ -305,8 +306,7 @@ def mptt_before_update(mapper, connection, instance):
             )
         # if just insert
         else:
-            tree_id = connection.scalar(
-                select([func.max(table.c.tree_id) + 1]))
+            tree_id = str(uuid.uuid4())
 
         connection.execute(
             table.update(table_pk.in_(subtree))

--- a/sqlalchemy_mptt/mixins.py
+++ b/sqlalchemy_mptt/mixins.py
@@ -10,7 +10,7 @@
 """
 SQLAlchemy nested sets mixin
 """
-from sqlalchemy import Index, Column, Integer, ForeignKey, desc, asc
+from sqlalchemy import Index, Column, Integer, ForeignKey, desc, asc, Unicode
 from sqlalchemy.orm import backref, relationship, object_session
 from sqlalchemy.orm.session import Session
 from sqlalchemy.ext.declarative import declared_attr
@@ -67,7 +67,7 @@ class BaseNestedSets(object):
 
     @declared_attr
     def tree_id(cls):
-        return Column("tree_id", Integer)
+        return Column("tree_id", Unicode(32))
 
     @declared_attr
     def parent_id(cls):

--- a/sqlalchemy_mptt/tests/__init__.py
+++ b/sqlalchemy_mptt/tests/__init__.py
@@ -112,14 +112,17 @@ class TreeTestingMixin(
         node.move_after('1')
         self.session.flush()
 
-        self.assertEqual(node.tree_id, 2)
+        node1 = self.session.query(self.model). \
+            filter(self.model.get_pk_column() == 1).one()
+
+        self.assertEqual(node.tree_id, node1.tree_id)
         self.assertEqual(node.level, 1)
         self.assertEqual(node.parent_id, None)
 
-        self.assertEqual(children[0].tree_id, 2)
+        self.assertEqual(children[0].tree_id, node1.tree_id)
         self.assertEqual(children[0].parent_id, 4)
         self.assertEqual(children[0].level, 2)
 
-        self.assertEqual(children[1].tree_id, 2)
+        self.assertEqual(children[1].tree_id, node1.tree_id)
         self.assertEqual(children[1].parent_id, 4)
         self.assertEqual(children[1].level, 2)

--- a/sqlalchemy_mptt/tests/__init__.py
+++ b/sqlalchemy_mptt/tests/__init__.py
@@ -112,17 +112,16 @@ class TreeTestingMixin(
         node.move_after('1')
         self.session.flush()
 
-        node1 = self.session.query(self.model). \
-            filter(self.model.get_pk_column() == 1).one()
+        node = self.session.query(self.model). \
+            filter(self.model.get_pk_column() == 4).one()
 
-        self.assertEqual(node.tree_id, node1.tree_id)
         self.assertEqual(node.level, 1)
         self.assertEqual(node.parent_id, None)
 
-        self.assertEqual(children[0].tree_id, node1.tree_id)
+        self.assertEqual(children[0].tree_id, node.tree_id)
         self.assertEqual(children[0].parent_id, 4)
         self.assertEqual(children[0].level, 2)
 
-        self.assertEqual(children[1].tree_id, node1.tree_id)
+        self.assertEqual(children[1].tree_id, node.tree_id)
         self.assertEqual(children[1].parent_id, 4)
         self.assertEqual(children[1].level, 2)

--- a/sqlalchemy_mptt/tests/cases/edit_node.py
+++ b/sqlalchemy_mptt/tests/cases/edit_node.py
@@ -350,12 +350,12 @@ class Changes(object):
         """
         node4 = self.session.query(self.model)\
             .filter(self.model.get_pk_column() == 4).one()
+        node4.parent_id = 2
+        self.session.add(node4)
         node2 = self.session.query(self.model) \
             .filter(self.model.get_pk_column() == 12).one()
         node1 = self.session.query(self.model) \
-            .filter(self.model.get_pk_column() == 12).one()
-        node4.parent_id = 2
-        self.session.add(node4)
+            .filter(self.model.get_pk_column() == 1).one()
         #                 id lft rgt lvl parent tree
         self.assertEqual([(1,   1, 22, 1, None, node1.tree_id),
                           (2,   2, 15, 2,  1, node1.tree_id),

--- a/sqlalchemy_mptt/tests/cases/edit_node.py
+++ b/sqlalchemy_mptt/tests/cases/edit_node.py
@@ -444,7 +444,9 @@ class Changes(object):
             self.model.right: 0,
             self.model.level: 0
         })
-        self.model.rebuild(self.session, 1)
+        node = self.session.query(self.model)\
+            .filter(self.model.get_pk_column() == 1).one()
+        self.model.rebuild(self.session, node.tree_id)
         #                 id lft rgt lvl parent tree
         self.assertEqual(self.result.all(),
                          [(1,   1, 22, 1, None, 1),

--- a/sqlalchemy_mptt/tests/cases/edit_node.py
+++ b/sqlalchemy_mptt/tests/cases/edit_node.py
@@ -17,32 +17,36 @@ class Changes(object):
         node = self.session.query(self.model)\
             .filter(self.model.get_pk_column() == 4).one()
         node.visible = True
+
+        node2 = self.session.query(self.model)\
+            .filter(self.model.get_pk_column() == 12).one()
+
         self.session.add(node)
         #                 id lft rgt lvl parent tree
         self.assertEqual(
-            [(1,   1, 22, 1, None, 1),
-             (2,   2,  5, 2,  1, 1),
-             (3,   3,  4, 3,  2, 1),
-             (4,   6, 11, 2,  1, 1),
-             (5,   7,  8, 3,  4, 1),
-             (6,   9, 10, 3,  4, 1),
-             (7,  12, 21, 2,  1, 1),
-             (8,  13, 16, 3,  7, 1),
-             (9,  14, 15, 4,  8, 1),
-             (10, 17, 20, 3,  7, 1),
-             (11, 18, 19, 4, 10, 1),
+            [(1,   1, 22, 1, None, node.tree_id),
+             (2,   2,  5, 2,  1, node.tree_id),
+             (3,   3,  4, 3,  2, node.tree_id),
+             (4,   6, 11, 2,  1, node.tree_id),
+             (5,   7,  8, 3,  4, node.tree_id),
+             (6,   9, 10, 3,  4, node.tree_id),
+             (7,  12, 21, 2,  1, node.tree_id),
+             (8,  13, 16, 3,  7, node.tree_id),
+             (9,  14, 15, 4,  8, node.tree_id),
+             (10, 17, 20, 3,  7, node.tree_id),
+             (11, 18, 19, 4, 10, node.tree_id),
 
-             (12,  1, 22, 1, None, 2),
-             (13,  2,  5, 2, 12, 2),
-             (14,  3,  4, 3, 13, 2),
-             (15,  6, 11, 2, 12, 2),
-             (16,  7,  8, 3, 15, 2),
-             (17,  9, 10, 3, 15, 2),
-             (18, 12, 21, 2, 12, 2),
-             (19, 13, 16, 3, 18, 2),
-             (20, 14, 15, 4, 19, 2),
-             (21, 17, 20, 3, 18, 2),
-             (22, 18, 19, 4, 21, 2)], self.result.all())  # flake8: noqa
+             (12,  1, 22, 1, None, node2.tree_id),
+             (13,  2,  5, 2, 12, node2.tree_id),
+             (14,  3,  4, 3, 13, node2.tree_id),
+             (15,  6, 11, 2, 12, node2.tree_id),
+             (16,  7,  8, 3, 15, node2.tree_id),
+             (17,  9, 10, 3, 15, node2.tree_id),
+             (18, 12, 21, 2, 12, node2.tree_id),
+             (19, 13, 16, 3, 18, node2.tree_id),
+             (20, 14, 15, 4, 19, node2.tree_id),
+             (21, 17, 20, 3, 18, node2.tree_id),
+             (22, 18, 19, 4, 21, node2.tree_id)], self.result.all())  # flake8: noqa
 
     def test_update_wo_move_like_sacrud_save(self):
         """ Just change attr from node w/o move
@@ -62,31 +66,35 @@ class Changes(object):
             .filter(self.model.get_pk_column() == 4).one()
         node.parent_id = '1'
         node.visible = True
+
+        node2 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
+
         self.session.add(node)
         #                 id lft rgt lvl parent tree
-        self.assertEqual([(1,   1, 22, 1, None, 1),
-                          (2,   2,  5, 2,  1, 1),
-                          (3,   3,  4, 3,  2, 1),
-                          (4,   6, 11, 2,  1, 1),
-                          (5,   7,  8, 3,  4, 1),
-                          (6,   9, 10, 3,  4, 1),
-                          (7,  12, 21, 2,  1, 1),
-                          (8,  13, 16, 3,  7, 1),
-                          (9,  14, 15, 4,  8, 1),
-                          (10, 17, 20, 3,  7, 1),
-                          (11, 18, 19, 4, 10, 1),
+        self.assertEqual([(1,   1, 22, 1, None, node.tree_id),
+                          (2,   2,  5, 2,  1, node.tree_id),
+                          (3,   3,  4, 3,  2, node.tree_id),
+                          (4,   6, 11, 2,  1, node.tree_id),
+                          (5,   7,  8, 3,  4, node.tree_id),
+                          (6,   9, 10, 3,  4, node.tree_id),
+                          (7,  12, 21, 2,  1, node.tree_id),
+                          (8,  13, 16, 3,  7, node.tree_id),
+                          (9,  14, 15, 4,  8, node.tree_id),
+                          (10, 17, 20, 3,  7, node.tree_id),
+                          (11, 18, 19, 4, 10, node.tree_id),
 
-                          (12,  1, 22, 1, None, 2),
-                          (13,  2,  5, 2, 12, 2),
-                          (14,  3,  4, 3, 13, 2),
-                          (15,  6, 11, 2, 12, 2),
-                          (16,  7,  8, 3, 15, 2),
-                          (17,  9, 10, 3, 15, 2),
-                          (18, 12, 21, 2, 12, 2),
-                          (19, 13, 16, 3, 18, 2),
-                          (20, 14, 15, 4, 19, 2),
-                          (21, 17, 20, 3, 18, 2),
-                          (22, 18, 19, 4, 21, 2)], self.result.all())
+                          (12,  1, 22, 1, None, node2.tree_id),
+                          (13,  2,  5, 2, 12, node2.tree_id),
+                          (14,  3,  4, 3, 13, node2.tree_id),
+                          (15,  6, 11, 2, 12, node2.tree_id),
+                          (16,  7,  8, 3, 15, node2.tree_id),
+                          (17,  9, 10, 3, 15, node2.tree_id),
+                          (18, 12, 21, 2, 12, node2.tree_id),
+                          (19, 13, 16, 3, 18, node2.tree_id),
+                          (20, 14, 15, 4, 19, node2.tree_id),
+                          (21, 17, 20, 3, 18, node2.tree_id),
+                          (22, 18, 19, 4, 21, node2.tree_id)], self.result.all())
 
     def test_insert_node(self):
         """ Insert node with parent==6
@@ -113,33 +121,35 @@ class Changes(object):
             4                      10(23)11  16(9)17  20(11)21
         """
         node = self.model(parent_id=6)
+        node2 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
         self.session.add(node)
         #                 id lft rgt lvl parent tree
-        self.assertEqual([(1,   1, 24, 1, None, 1),
-                          (2,   2,  5, 2,  1, 1),
-                          (3,   3,  4, 3,  2, 1),
-                          (4,   6, 13, 2,  1, 1),
-                          (5,   7,  8, 3,  4, 1),
-                          (6,   9, 12, 3,  4, 1),
-                          (7,  14, 23, 2,  1, 1),
-                          (8,  15, 18, 3,  7, 1),
-                          (9,  16, 17, 4,  8, 1),
-                          (10, 19, 22, 3,  7, 1),
-                          (11, 20, 21, 4, 10, 1),
+        self.assertEqual([(1,   1, 24, 1, None, node.tree_id),
+                          (2,   2,  5, 2,  1, node.tree_id),
+                          (3,   3,  4, 3,  2, node.tree_id),
+                          (4,   6, 13, 2,  1, node.tree_id),
+                          (5,   7,  8, 3,  4, node.tree_id),
+                          (6,   9, 12, 3,  4, node.tree_id),
+                          (7,  14, 23, 2,  1, node.tree_id),
+                          (8,  15, 18, 3,  7, node.tree_id),
+                          (9,  16, 17, 4,  8, node.tree_id),
+                          (10, 19, 22, 3,  7, node.tree_id),
+                          (11, 20, 21, 4, 10, node.tree_id),
 
-                          (12,  1, 22, 1, None, 2),
-                          (13,  2,  5, 2, 12, 2),
-                          (14,  3,  4, 3, 13, 2),
-                          (15,  6, 11, 2, 12, 2),
-                          (16,  7,  8, 3, 15, 2),
-                          (17,  9, 10, 3, 15, 2),
-                          (18, 12, 21, 2, 12, 2),
-                          (19, 13, 16, 3, 18, 2),
-                          (20, 14, 15, 4, 19, 2),
-                          (21, 17, 20, 3, 18, 2),
-                          (22, 18, 19, 4, 21, 2),
+                          (12,  1, 22, 1, None, node2.tree_id),
+                          (13,  2,  5, 2, 12, node2.tree_id),
+                          (14,  3,  4, 3, 13, node2.tree_id),
+                          (15,  6, 11, 2, 12, node2.tree_id),
+                          (16,  7,  8, 3, 15, node2.tree_id),
+                          (17,  9, 10, 3, 15, node2.tree_id),
+                          (18, 12, 21, 2, 12, node2.tree_id),
+                          (19, 13, 16, 3, 18, node2.tree_id),
+                          (20, 14, 15, 4, 19, node2.tree_id),
+                          (21, 17, 20, 3, 18, node2.tree_id),
+                          (22, 18, 19, 4, 21, node2.tree_id),
 
-                          (23, 10, 11, 4, 6, 1)], self.result.all())
+                          (23, 10, 11, 4, 6, node.tree_id)], self.result.all())
 
     def test_insert_node_near_subtree(self):
         """ Insert node with parent==4
@@ -166,33 +176,35 @@ class Changes(object):
             4                                      16(9)17   20(11)21
         """
         node = self.model(parent_id=4)
+        node2 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
         self.session.add(node)
         #                 id lft rgt lvl parent tree
-        self.assertEqual([(1,   1, 24, 1, None, 1),
-                          (2,   2,  5, 2,  1, 1),
-                          (3,   3,  4, 3,  2, 1),
-                          (4,   6, 13, 2,  1, 1),
-                          (5,   7,  8, 3,  4, 1),
-                          (6,   9, 10, 3,  4, 1),
-                          (7,  14, 23, 2,  1, 1),
-                          (8,  15, 18, 3,  7, 1),
-                          (9,  16, 17, 4,  8, 1),
-                          (10, 19, 22, 3,  7, 1),
-                          (11, 20, 21, 4, 10, 1),
+        self.assertEqual([(1,   1, 24, 1, None, node.tree_id),
+                          (2,   2,  5, 2,  1, node.tree_id),
+                          (3,   3,  4, 3,  2, node.tree_id),
+                          (4,   6, 13, 2,  1, node.tree_id),
+                          (5,   7,  8, 3,  4, node.tree_id),
+                          (6,   9, 10, 3,  4, node.tree_id),
+                          (7,  14, 23, 2,  1, node.tree_id),
+                          (8,  15, 18, 3,  7, node.tree_id),
+                          (9,  16, 17, 4,  8, node.tree_id),
+                          (10, 19, 22, 3,  7, node.tree_id),
+                          (11, 20, 21, 4, 10, node.tree_id),
 
-                          (12,  1, 22, 1, None, 2),
-                          (13,  2,  5, 2, 12, 2),
-                          (14,  3,  4, 3, 13, 2),
-                          (15,  6, 11, 2, 12, 2),
-                          (16,  7,  8, 3, 15, 2),
-                          (17,  9, 10, 3, 15, 2),
-                          (18, 12, 21, 2, 12, 2),
-                          (19, 13, 16, 3, 18, 2),
-                          (20, 14, 15, 4, 19, 2),
-                          (21, 17, 20, 3, 18, 2),
-                          (22, 18, 19, 4, 21, 2),
+                          (12,  1, 22, 1, None, node2.tree_id),
+                          (13,  2,  5, 2, 12, node2.tree_id),
+                          (14,  3,  4, 3, 13, node2.tree_id),
+                          (15,  6, 11, 2, 12, node2.tree_id),
+                          (16,  7,  8, 3, 15, node2.tree_id),
+                          (17,  9, 10, 3, 15, node2.tree_id),
+                          (18, 12, 21, 2, 12, node2.tree_id),
+                          (19, 13, 16, 3, 18, node2.tree_id),
+                          (20, 14, 15, 4, 19, node2.tree_id),
+                          (21, 17, 20, 3, 18, node2.tree_id),
+                          (22, 18, 19, 4, 21, node2.tree_id),
 
-                          (23, 11, 12, 3,  4, 1)], self.result.all())
+                          (23, 11, 12, 3,  4, node.tree_id)], self.result.all())
 
     def test_insert_after_node(self):
         pass
@@ -222,28 +234,30 @@ class Changes(object):
         """
         node = self.session.query(self.model)\
             .filter(self.model.get_pk_column() == 4).one()
+        node2 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
         self.session.delete(node)
         #                 id lft rgt lvl parent tree
-        self.assertEqual([(1,   1, 16, 1, None, 1),
-                          (2,   2,  5, 2,  1, 1),
-                          (3,   3,  4, 3,  2, 1),
-                          (7,   6, 15, 2,  1, 1),
-                          (8,   7, 10, 3,  7, 1),
-                          (9,   8,  9, 4,  8, 1),
-                          (10, 11, 14, 3,  7, 1),
-                          (11, 12, 13, 4, 10, 1),
+        self.assertEqual([(1,   1, 16, 1, None, node.tree_id),
+                          (2,   2,  5, 2,  1, node.tree_id),
+                          (3,   3,  4, 3,  2, node.tree_id),
+                          (7,   6, 15, 2,  1, node.tree_id),
+                          (8,   7, 10, 3,  7, node.tree_id),
+                          (9,   8,  9, 4,  8, node.tree_id),
+                          (10, 11, 14, 3,  7, node.tree_id),
+                          (11, 12, 13, 4, 10, node.tree_id),
 
-                          (12,  1, 22, 1, None, 2),
-                          (13,  2,  5, 2, 12, 2),
-                          (14,  3,  4, 3, 13, 2),
-                          (15,  6, 11, 2, 12, 2),
-                          (16,  7,  8, 3, 15, 2),
-                          (17,  9, 10, 3, 15, 2),
-                          (18, 12, 21, 2, 12, 2),
-                          (19, 13, 16, 3, 18, 2),
-                          (20, 14, 15, 4, 19, 2),
-                          (21, 17, 20, 3, 18, 2),
-                          (22, 18, 19, 4, 21, 2)], self.result.all())
+                          (12,  1, 22, 1, None, node2.tree_id),
+                          (13,  2,  5, 2, 12, node2.tree_id),
+                          (14,  3,  4, 3, 13, node2.tree_id),
+                          (15,  6, 11, 2, 12, node2.tree_id),
+                          (16,  7,  8, 3, 15, node2.tree_id),
+                          (17,  9, 10, 3, 15, node2.tree_id),
+                          (18, 12, 21, 2, 12, node2.tree_id),
+                          (19, 13, 16, 3, 18, node2.tree_id),
+                          (20, 14, 15, 4, 19, node2.tree_id),
+                          (21, 17, 20, 3, 18, node2.tree_id),
+                          (22, 18, 19, 4, 21, node2.tree_id)], self.result.all())
 
     def test_update_node(self):
         """ Set parent_id==5 for node(8)
@@ -272,32 +286,34 @@ class Changes(object):
         """
         node = self.session.query(self.model)\
             .filter(self.model.get_pk_column() == 8).one()
+        node2 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
         node.parent_id = 5
         self.session.add(node)
         #                 id lft rgt lvl parent tree
-        self.assertEqual([(1, 1, 22, 1, None, 1),
-                          (2,   2,  5, 2,  1, 1),
-                          (3,   3,  4, 3,  2, 1),
-                          (4,   6, 15, 2,  1, 1),
-                          (5,   7, 12, 3,  4, 1),
-                          (6,  13, 14, 3,  4, 1),
-                          (7,  16, 21, 2,  1, 1),
-                          (8,   8, 11, 4,  5, 1),
-                          (9,   9, 10, 5,  8, 1),
-                          (10, 17, 20, 3,  7, 1),
-                          (11, 18, 19, 4, 10, 1),
+        self.assertEqual([(1, 1, 22, 1, None, node.tree_id),
+                          (2,   2,  5, 2,  1, node.tree_id),
+                          (3,   3,  4, 3,  2, node.tree_id),
+                          (4,   6, 15, 2,  1, node.tree_id),
+                          (5,   7, 12, 3,  4, node.tree_id),
+                          (6,  13, 14, 3,  4, node.tree_id),
+                          (7,  16, 21, 2,  1, node.tree_id),
+                          (8,   8, 11, 4,  5, node.tree_id),
+                          (9,   9, 10, 5,  8, node.tree_id),
+                          (10, 17, 20, 3,  7, node.tree_id),
+                          (11, 18, 19, 4, 10, node.tree_id),
 
-                          (12,  1, 22, 1, None, 2),
-                          (13,  2,  5, 2, 12, 2),
-                          (14,  3,  4, 3, 13, 2),
-                          (15,  6, 11, 2, 12, 2),
-                          (16,  7,  8, 3, 15, 2),
-                          (17,  9, 10, 3, 15, 2),
-                          (18, 12, 21, 2, 12, 2),
-                          (19, 13, 16, 3, 18, 2),
-                          (20, 14, 15, 4, 19, 2),
-                          (21, 17, 20, 3, 18, 2),
-                          (22, 18, 19, 4, 21, 2)], self.result.all())
+                          (12,  1, 22, 1, None, node2.tree_id),
+                          (13,  2,  5, 2, 12, node2.tree_id),
+                          (14,  3,  4, 3, 13, node2.tree_id),
+                          (15,  6, 11, 2, 12, node2.tree_id),
+                          (16,  7,  8, 3, 15, node2.tree_id),
+                          (17,  9, 10, 3, 15, node2.tree_id),
+                          (18, 12, 21, 2, 12, node2.tree_id),
+                          (19, 13, 16, 3, 18, node2.tree_id),
+                          (20, 14, 15, 4, 19, node2.tree_id),
+                          (21, 17, 20, 3, 18, node2.tree_id),
+                          (22, 18, 19, 4, 21, node2.tree_id)], self.result.all())
 
         """ level               Move 8 - > 5
                 1                     1(1)22
@@ -325,34 +341,38 @@ class Changes(object):
                      |
                 6  6(9)7
         """
-        node = self.session.query(self.model)\
+        node4 = self.session.query(self.model)\
             .filter(self.model.get_pk_column() == 4).one()
-        node.parent_id = 2
-        self.session.add(node)
+        node2 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
+        node1 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
+        node4.parent_id = 2
+        self.session.add(node4)
         #                 id lft rgt lvl parent tree
-        self.assertEqual([(1,   1, 22, 1, None, 1),
-                          (2,   2, 15, 2,  1, 1),
-                          (3,  13, 14, 3,  2, 1),
-                          (4,   3, 12, 3,  2, 1),
-                          (5,   4,  9, 4,  4, 1),
-                          (6,  10, 11, 4,  4, 1),
-                          (7,  16, 21, 2,  1, 1),
-                          (8,   5,  8, 5,  5, 1),
-                          (9,   6,  7, 6,  8, 1),
-                          (10, 17, 20, 3,  7, 1),
-                          (11, 18, 19, 4, 10, 1),
+        self.assertEqual([(1,   1, 22, 1, None, node1.tree_id),
+                          (2,   2, 15, 2,  1, node1.tree_id),
+                          (3,  13, 14, 3,  2, node1.tree_id),
+                          (4,   3, 12, 3,  2, node1.tree_id),
+                          (5,   4,  9, 4,  4, node1.tree_id),
+                          (6,  10, 11, 4,  4, node1.tree_id),
+                          (7,  16, 21, 2,  1, node1.tree_id),
+                          (8,   5,  8, 5,  5, node1.tree_id),
+                          (9,   6,  7, 6,  8, node1.tree_id),
+                          (10, 17, 20, 3,  7, node1.tree_id),
+                          (11, 18, 19, 4, 10, node1.tree_id),
 
-                          (12,  1, 22, 1, None, 2),
-                          (13,  2,  5, 2, 12, 2),
-                          (14,  3,  4, 3, 13, 2),
-                          (15,  6, 11, 2, 12, 2),
-                          (16,  7,  8, 3, 15, 2),
-                          (17,  9, 10, 3, 15, 2),
-                          (18, 12, 21, 2, 12, 2),
-                          (19, 13, 16, 3, 18, 2),
-                          (20, 14, 15, 4, 19, 2),
-                          (21, 17, 20, 3, 18, 2),
-                          (22, 18, 19, 4, 21, 2)], self.result.all())
+                          (12,  1, 22, 1, None, node2.tree_id),
+                          (13,  2,  5, 2, 12, node2.tree_id),
+                          (14,  3,  4, 3, 13, node2.tree_id),
+                          (15,  6, 11, 2, 12, node2.tree_id),
+                          (16,  7,  8, 3, 15, node2.tree_id),
+                          (17,  9, 10, 3, 15, node2.tree_id),
+                          (18, 12, 21, 2, 12, node2.tree_id),
+                          (19, 13, 16, 3, 18, node2.tree_id),
+                          (20, 14, 15, 4, 19, node2.tree_id),
+                          (21, 17, 20, 3, 18, node2.tree_id),
+                          (22, 18, 19, 4, 21, node2.tree_id)], self.result.all())
 
         """ level               Move 4 - > 2
                 1                     1(1)22
@@ -383,34 +403,39 @@ class Changes(object):
                 5                                15(9)16
         """
 
-        node = self.session.query(self.model)\
+        node8 = self.session.query(self.model)\
             .filter(self.model.get_pk_column() == 8).one()
-        node.parent_id = 10
-        self.session.add(node)
-        #                 id lft rgt lvl parent tree
-        self.assertEqual([(1,   1, 22, 1, None, 1),
-                          (2,   2, 11, 2,  1, 1),
-                          (3,   9, 10, 3,  2, 1),
-                          (4,   3,  8, 3,  2, 1),
-                          (5,   4,  5, 4,  4, 1),
-                          (6,   6,  7, 4,  4, 1),
-                          (7,  12, 21, 2,  1, 1),
-                          (8,  14, 17, 4, 10, 1),
-                          (9,  15, 16, 5,  8, 1),
-                          (10, 13, 20, 3,  7, 1),
-                          (11, 18, 19, 4, 10, 1),
+        node8.parent_id = 10
+        self.session.add(node8)
 
-                          (12,  1, 22, 1, None, 2),
-                          (13,  2,  5, 2, 12, 2),
-                          (14,  3,  4, 3, 13, 2),
-                          (15,  6, 11, 2, 12, 2),
-                          (16,  7,  8, 3, 15, 2),
-                          (17,  9, 10, 3, 15, 2),
-                          (18, 12, 21, 2, 12, 2),
-                          (19, 13, 16, 3, 18, 2),
-                          (20, 14, 15, 4, 19, 2),
-                          (21, 17, 20, 3, 18, 2),
-                          (22, 18, 19, 4, 21, 2)], self.result.all())
+        node1 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 1).one()
+        node12 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
+        #                 id lft rgt lvl parent tree
+        self.assertEqual([(1,   1, 22, 1, None, node1.tree_id),
+                          (2,   2, 11, 2,  1, node1.tree_id),
+                          (3,   9, 10, 3,  2, node1.tree_id),
+                          (4,   3,  8, 3,  2, node1.tree_id),
+                          (5,   4,  5, 4,  4, node1.tree_id),
+                          (6,   6,  7, 4,  4, node1.tree_id),
+                          (7,  12, 21, 2,  1, node1.tree_id),
+                          (8,  14, 17, 4, 10, node1.tree_id),
+                          (9,  15, 16, 5,  8, node1.tree_id),
+                          (10, 13, 20, 3,  7, node1.tree_id),
+                          (11, 18, 19, 4, 10, node1.tree_id),
+
+                          (12,  1, 22, 1, None, node12.tree_id),
+                          (13,  2,  5, 2, 12, node12.tree_id),
+                          (14,  3,  4, 3, 13, node12.tree_id),
+                          (15,  6, 11, 2, 12, node12.tree_id),
+                          (16,  7,  8, 3, 15, node12.tree_id),
+                          (17,  9, 10, 3, 15, node12.tree_id),
+                          (18, 12, 21, 2, 12, node12.tree_id),
+                          (19, 13, 16, 3, 18, node12.tree_id),
+                          (20, 14, 15, 4, 19, node12.tree_id),
+                          (21, 17, 20, 3, 18, node12.tree_id),
+                          (22, 18, 19, 4, 21, node12.tree_id)], self.result.all())
 
     def test_rebuild(self):
         """ Rebuild tree with tree_id==1
@@ -444,58 +469,60 @@ class Changes(object):
             self.model.right: 0,
             self.model.level: 0
         })
-        node = self.session.query(self.model)\
+        node1 = self.session.query(self.model)\
             .filter(self.model.get_pk_column() == 1).one()
-        self.model.rebuild(self.session, node.tree_id)
+        node2 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
+        self.model.rebuild(self.session, node1.tree_id)
         #                 id lft rgt lvl parent tree
         self.assertEqual(self.result.all(),
-                         [(1,   1, 22, 1, None, 1),
-                          (2,   2,  5, 2, 1,  1),
-                          (3,   3,  4, 3, 2,  1),
-                          (4,   6, 11, 2, 1,  1),
-                          (5,   7,  8, 3, 4,  1),
-                          (6,   9, 10, 3, 4,  1),
-                          (7,  12, 21, 2, 1,  1),
-                          (8,  13, 16, 3, 7,  1),
-                          (9,  14, 15, 4, 8,  1),
-                          (10, 17, 20, 3, 7,  1),
-                          (11, 18, 19, 4, 10, 1),
+                         [(1,   1, 22, 1, None, node1.tree_id),
+                          (2,   2,  5, 2, 1,  node1.tree_id),
+                          (3,   3,  4, 3, 2,  node1.tree_id),
+                          (4,   6, 11, 2, 1,  node1.tree_id),
+                          (5,   7,  8, 3, 4,  node1.tree_id),
+                          (6,   9, 10, 3, 4,  node1.tree_id),
+                          (7,  12, 21, 2, 1,  node1.tree_id),
+                          (8,  13, 16, 3, 7,  node1.tree_id),
+                          (9,  14, 15, 4, 8,  node1.tree_id),
+                          (10, 17, 20, 3, 7,  node1.tree_id),
+                          (11, 18, 19, 4, 10, node1.tree_id),
 
-                          (12, 0, 0, 0, None, 2),
-                          (13, 0, 0, 0, 12, 2),
-                          (14, 0, 0, 0, 13, 2),
-                          (15, 0, 0, 0, 12, 2),
-                          (16, 0, 0, 0, 15, 2),
-                          (17, 0, 0, 0, 15, 2),
-                          (18, 0, 0, 0, 12, 2),
-                          (19, 0, 0, 0, 18, 2),
-                          (20, 0, 0, 0, 19, 2),
-                          (21, 0, 0, 0, 18, 2),
-                          (22, 0, 0, 0, 21, 2)])
+                          (12, 0, 0, 0, None, node2.tree_id),
+                          (13, 0, 0, 0, 12, node2.tree_id),
+                          (14, 0, 0, 0, 13, node2.tree_id),
+                          (15, 0, 0, 0, 12, node2.tree_id),
+                          (16, 0, 0, 0, 15, node2.tree_id),
+                          (17, 0, 0, 0, 15, node2.tree_id),
+                          (18, 0, 0, 0, 12, node2.tree_id),
+                          (19, 0, 0, 0, 18, node2.tree_id),
+                          (20, 0, 0, 0, 19, node2.tree_id),
+                          (21, 0, 0, 0, 18, node2.tree_id),
+                          (22, 0, 0, 0, 21, node2.tree_id)])
 
         self.model.rebuild(self.session)
         #                 id lft rgt lvl parent tree
         self.assertEqual(self.result.all(),
-                         [(1,   1, 22, 1, None, 1),
-                          (2,   2,  5, 2, 1,  1),
-                          (3,   3,  4, 3, 2,  1),
-                          (4,   6, 11, 2, 1,  1),
-                          (5,   7,  8, 3, 4,  1),
-                          (6,   9, 10, 3, 4,  1),
-                          (7,  12, 21, 2, 1,  1),
-                          (8,  13, 16, 3, 7,  1),
-                          (9,  14, 15, 4, 8,  1),
-                          (10, 17, 20, 3, 7,  1),
-                          (11, 18, 19, 4, 10, 1),
+                         [(1,   1, 22, 1, None, node1.tree_id),
+                          (2,   2,  5, 2, 1,  node1.tree_id),
+                          (3,   3,  4, 3, 2,  node1.tree_id),
+                          (4,   6, 11, 2, 1,  node1.tree_id),
+                          (5,   7,  8, 3, 4,  node1.tree_id),
+                          (6,   9, 10, 3, 4,  node1.tree_id),
+                          (7,  12, 21, 2, 1,  node1.tree_id),
+                          (8,  13, 16, 3, 7,  node1.tree_id),
+                          (9,  14, 15, 4, 8,  node1.tree_id),
+                          (10, 17, 20, 3, 7,  node1.tree_id),
+                          (11, 18, 19, 4, 10, node1.tree_id),
 
-                          (12,  1, 22, 1, None, 2),
-                          (13,  2,  5, 2, 12, 2),
-                          (14,  3,  4, 3, 13, 2),
-                          (15,  6, 11, 2, 12, 2),
-                          (16,  7,  8, 3, 15, 2),
-                          (17,  9, 10, 3, 15, 2),
-                          (18, 12, 21, 2, 12, 2),
-                          (19, 13, 16, 3, 18, 2),
-                          (20, 14, 15, 4, 19, 2),
-                          (21, 17, 20, 3, 18, 2),
-                          (22, 18, 19, 4, 21, 2)])
+                          (12,  1, 22, 1, None, node2.tree_id),
+                          (13,  2,  5, 2, 12, node2.tree_id),
+                          (14,  3,  4, 3, 13, node2.tree_id),
+                          (15,  6, 11, 2, 12, node2.tree_id),
+                          (16,  7,  8, 3, 15, node2.tree_id),
+                          (17,  9, 10, 3, 15, node2.tree_id),
+                          (18, 12, 21, 2, 12, node2.tree_id),
+                          (19, 13, 16, 3, 18, node2.tree_id),
+                          (20, 14, 15, 4, 19, node2.tree_id),
+                          (21, 17, 20, 3, 18, node2.tree_id),
+                          (22, 18, 19, 4, 21, node2.tree_id)])

--- a/sqlalchemy_mptt/tests/cases/edit_node.py
+++ b/sqlalchemy_mptt/tests/cases/edit_node.py
@@ -121,33 +121,35 @@ class Changes(object):
             4                      10(23)11  16(9)17  20(11)21
         """
         node = self.model(parent_id=6)
-        node2 = self.session.query(self.model) \
-            .filter(self.model.get_pk_column() == 12).one()
         self.session.add(node)
+        node1 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 1).one()
+        node12 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
         #                 id lft rgt lvl parent tree
-        self.assertEqual([(1,   1, 24, 1, None, node.tree_id),
-                          (2,   2,  5, 2,  1, node.tree_id),
-                          (3,   3,  4, 3,  2, node.tree_id),
-                          (4,   6, 13, 2,  1, node.tree_id),
-                          (5,   7,  8, 3,  4, node.tree_id),
-                          (6,   9, 12, 3,  4, node.tree_id),
-                          (7,  14, 23, 2,  1, node.tree_id),
-                          (8,  15, 18, 3,  7, node.tree_id),
-                          (9,  16, 17, 4,  8, node.tree_id),
-                          (10, 19, 22, 3,  7, node.tree_id),
-                          (11, 20, 21, 4, 10, node.tree_id),
+        self.assertEqual([(1,   1, 24, 1, None, node1.tree_id),
+                          (2,   2,  5, 2,  1, node1.tree_id),
+                          (3,   3,  4, 3,  2, node1.tree_id),
+                          (4,   6, 13, 2,  1, node1.tree_id),
+                          (5,   7,  8, 3,  4, node1.tree_id),
+                          (6,   9, 12, 3,  4, node1.tree_id),
+                          (7,  14, 23, 2,  1, node1.tree_id),
+                          (8,  15, 18, 3,  7, node1.tree_id),
+                          (9,  16, 17, 4,  8, node1.tree_id),
+                          (10, 19, 22, 3,  7, node1.tree_id),
+                          (11, 20, 21, 4, 10, node1.tree_id),
 
-                          (12,  1, 22, 1, None, node2.tree_id),
-                          (13,  2,  5, 2, 12, node2.tree_id),
-                          (14,  3,  4, 3, 13, node2.tree_id),
-                          (15,  6, 11, 2, 12, node2.tree_id),
-                          (16,  7,  8, 3, 15, node2.tree_id),
-                          (17,  9, 10, 3, 15, node2.tree_id),
-                          (18, 12, 21, 2, 12, node2.tree_id),
-                          (19, 13, 16, 3, 18, node2.tree_id),
-                          (20, 14, 15, 4, 19, node2.tree_id),
-                          (21, 17, 20, 3, 18, node2.tree_id),
-                          (22, 18, 19, 4, 21, node2.tree_id),
+                          (12,  1, 22, 1, None, node12.tree_id),
+                          (13,  2,  5, 2, 12, node12.tree_id),
+                          (14,  3,  4, 3, 13, node12.tree_id),
+                          (15,  6, 11, 2, 12, node12.tree_id),
+                          (16,  7,  8, 3, 15, node12.tree_id),
+                          (17,  9, 10, 3, 15, node12.tree_id),
+                          (18, 12, 21, 2, 12, node12.tree_id),
+                          (19, 13, 16, 3, 18, node12.tree_id),
+                          (20, 14, 15, 4, 19, node12.tree_id),
+                          (21, 17, 20, 3, 18, node12.tree_id),
+                          (22, 18, 19, 4, 21, node12.tree_id),
 
                           (23, 10, 11, 4, 6, node.tree_id)], self.result.all())
 
@@ -176,33 +178,35 @@ class Changes(object):
             4                                      16(9)17   20(11)21
         """
         node = self.model(parent_id=4)
-        node2 = self.session.query(self.model) \
-            .filter(self.model.get_pk_column() == 12).one()
         self.session.add(node)
+        node1 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 1).one()
+        node12 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
         #                 id lft rgt lvl parent tree
-        self.assertEqual([(1,   1, 24, 1, None, node.tree_id),
-                          (2,   2,  5, 2,  1, node.tree_id),
-                          (3,   3,  4, 3,  2, node.tree_id),
-                          (4,   6, 13, 2,  1, node.tree_id),
-                          (5,   7,  8, 3,  4, node.tree_id),
-                          (6,   9, 10, 3,  4, node.tree_id),
-                          (7,  14, 23, 2,  1, node.tree_id),
-                          (8,  15, 18, 3,  7, node.tree_id),
-                          (9,  16, 17, 4,  8, node.tree_id),
-                          (10, 19, 22, 3,  7, node.tree_id),
-                          (11, 20, 21, 4, 10, node.tree_id),
+        self.assertEqual([(1,   1, 24, 1, None, node1.tree_id),
+                          (2,   2,  5, 2,  1, node1.tree_id),
+                          (3,   3,  4, 3,  2, node1.tree_id),
+                          (4,   6, 13, 2,  1, node1.tree_id),
+                          (5,   7,  8, 3,  4, node1.tree_id),
+                          (6,   9, 10, 3,  4, node1.tree_id),
+                          (7,  14, 23, 2,  1, node1.tree_id),
+                          (8,  15, 18, 3,  7, node1.tree_id),
+                          (9,  16, 17, 4,  8, node1.tree_id),
+                          (10, 19, 22, 3,  7, node1.tree_id),
+                          (11, 20, 21, 4, 10, node1.tree_id),
 
-                          (12,  1, 22, 1, None, node2.tree_id),
-                          (13,  2,  5, 2, 12, node2.tree_id),
-                          (14,  3,  4, 3, 13, node2.tree_id),
-                          (15,  6, 11, 2, 12, node2.tree_id),
-                          (16,  7,  8, 3, 15, node2.tree_id),
-                          (17,  9, 10, 3, 15, node2.tree_id),
-                          (18, 12, 21, 2, 12, node2.tree_id),
-                          (19, 13, 16, 3, 18, node2.tree_id),
-                          (20, 14, 15, 4, 19, node2.tree_id),
-                          (21, 17, 20, 3, 18, node2.tree_id),
-                          (22, 18, 19, 4, 21, node2.tree_id),
+                          (12,  1, 22, 1, None, node12.tree_id),
+                          (13,  2,  5, 2, 12, node12.tree_id),
+                          (14,  3,  4, 3, 13, node12.tree_id),
+                          (15,  6, 11, 2, 12, node12.tree_id),
+                          (16,  7,  8, 3, 15, node12.tree_id),
+                          (17,  9, 10, 3, 15, node12.tree_id),
+                          (18, 12, 21, 2, 12, node12.tree_id),
+                          (19, 13, 16, 3, 18, node12.tree_id),
+                          (20, 14, 15, 4, 19, node12.tree_id),
+                          (21, 17, 20, 3, 18, node12.tree_id),
+                          (22, 18, 19, 4, 21, node12.tree_id),
 
                           (23, 11, 12, 3,  4, node.tree_id)], self.result.all())
 
@@ -286,34 +290,37 @@ class Changes(object):
         """
         node = self.session.query(self.model)\
             .filter(self.model.get_pk_column() == 8).one()
-        node2 = self.session.query(self.model) \
-            .filter(self.model.get_pk_column() == 12).one()
         node.parent_id = 5
         self.session.add(node)
-        #                 id lft rgt lvl parent tree
-        self.assertEqual([(1, 1, 22, 1, None, node.tree_id),
-                          (2,   2,  5, 2,  1, node.tree_id),
-                          (3,   3,  4, 3,  2, node.tree_id),
-                          (4,   6, 15, 2,  1, node.tree_id),
-                          (5,   7, 12, 3,  4, node.tree_id),
-                          (6,  13, 14, 3,  4, node.tree_id),
-                          (7,  16, 21, 2,  1, node.tree_id),
-                          (8,   8, 11, 4,  5, node.tree_id),
-                          (9,   9, 10, 5,  8, node.tree_id),
-                          (10, 17, 20, 3,  7, node.tree_id),
-                          (11, 18, 19, 4, 10, node.tree_id),
 
-                          (12,  1, 22, 1, None, node2.tree_id),
-                          (13,  2,  5, 2, 12, node2.tree_id),
-                          (14,  3,  4, 3, 13, node2.tree_id),
-                          (15,  6, 11, 2, 12, node2.tree_id),
-                          (16,  7,  8, 3, 15, node2.tree_id),
-                          (17,  9, 10, 3, 15, node2.tree_id),
-                          (18, 12, 21, 2, 12, node2.tree_id),
-                          (19, 13, 16, 3, 18, node2.tree_id),
-                          (20, 14, 15, 4, 19, node2.tree_id),
-                          (21, 17, 20, 3, 18, node2.tree_id),
-                          (22, 18, 19, 4, 21, node2.tree_id)], self.result.all())
+        node1 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 1).one()
+        node12 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
+        #                 id lft rgt lvl parent tree
+        self.assertEqual([(1, 1, 22, 1, None, node1.tree_id),
+                          (2,   2,  5, 2,  1, node1.tree_id),
+                          (3,   3,  4, 3,  2, node1.tree_id),
+                          (4,   6, 15, 2,  1, node1.tree_id),
+                          (5,   7, 12, 3,  4, node1.tree_id),
+                          (6,  13, 14, 3,  4, node1.tree_id),
+                          (7,  16, 21, 2,  1, node1.tree_id),
+                          (8,   8, 11, 4,  5, node1.tree_id),
+                          (9,   9, 10, 5,  8, node1.tree_id),
+                          (10, 17, 20, 3,  7, node1.tree_id),
+                          (11, 18, 19, 4, 10, node1.tree_id),
+
+                          (12,  1, 22, 1, None, node12.tree_id),
+                          (13,  2,  5, 2, 12, node12.tree_id),
+                          (14,  3,  4, 3, 13, node12.tree_id),
+                          (15,  6, 11, 2, 12, node12.tree_id),
+                          (16,  7,  8, 3, 15, node12.tree_id),
+                          (17,  9, 10, 3, 15, node12.tree_id),
+                          (18, 12, 21, 2, 12, node12.tree_id),
+                          (19, 13, 16, 3, 18, node12.tree_id),
+                          (20, 14, 15, 4, 19, node12.tree_id),
+                          (21, 17, 20, 3, 18, node12.tree_id),
+                          (22, 18, 19, 4, 21, node12.tree_id)], self.result.all())
 
         """ level               Move 8 - > 5
                 1                     1(1)22

--- a/sqlalchemy_mptt/tests/cases/get_tree.py
+++ b/sqlalchemy_mptt/tests/cases/get_tree.py
@@ -59,7 +59,8 @@ class Tree(object):
                                         {'node': go(21),
                                          'children': [{'node': go(22)}]}]}]}]
 
-        self.assertEqual(tree, reference_tree)
+        for element in reference_tree:
+            self.assertTrue(element in tree)
 
     def test_get_tree_count_query(self):
         """
@@ -131,7 +132,8 @@ class Tree(object):
              'id': 12, 'label': '<Node (12)>'}]
 
         tree = self.model.get_tree(self.session, json=True)
-        self.assertEqual(tree, reference_tree)
+        for element in reference_tree:
+            self.assertTrue(element in tree)
 
     def test_get_json_tree_with_custom_field(self):
         """.. note::
@@ -190,7 +192,8 @@ class Tree(object):
              'id': 12, 'label': '<Node (12)>'}]
 
         tree = self.model.get_tree(self.session, json=True, json_fields=fields)
-        self.assertEqual(tree, reference_tree)
+        for element in reference_tree:
+            self.assertTrue(element in tree)
 
     def test_leftsibling_in_level(self):
         """ Node to the left of the current node at the same level
@@ -275,7 +278,8 @@ class Tree(object):
                       {'node': go(11)}]}]
              }
         ]
-        self.assertEqual(tree, reference_tree)
+        for element in reference_tree:
+            self.assertTrue(element in tree)
 
     def test_path_to_root(self):
         """Generate path from a leaf or intermediate node to the root.

--- a/sqlalchemy_mptt/tests/cases/initialize.py
+++ b/sqlalchemy_mptt/tests/cases/initialize.py
@@ -93,28 +93,32 @@ class Initialize(object):
             4                                  14(20)15   18(22)19
 
         """
+        node1 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 1).one()
+        node2 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
         #    id lft rgt lvl parent tree
         self.assertEqual(
-            [(1,   1, 22, 1, None, 1),
-             (2,   2,  5, 2,  1, 1),
-             (3,   3,  4, 3,  2, 1),
-             (4,   6, 11, 2,  1, 1),
-             (5,   7,  8, 3,  4, 1),
-             (6,   9, 10, 3,  4, 1),
-             (7,  12, 21, 2,  1, 1),
-             (8,  13, 16, 3,  7, 1),
-             (9,  14, 15, 4,  8, 1),
-             (10, 17, 20, 3,  7, 1),
-             (11, 18, 19, 4, 10, 1),
+            [(1,   1, 22, 1, None, node1.tree_id),
+             (2,   2,  5, 2,  1, node1.tree_id),
+             (3,   3,  4, 3,  2, node1.tree_id),
+             (4,   6, 11, 2,  1, node1.tree_id),
+             (5,   7,  8, 3,  4, node1.tree_id),
+             (6,   9, 10, 3,  4, node1.tree_id),
+             (7,  12, 21, 2,  1, node1.tree_id),
+             (8,  13, 16, 3,  7, node1.tree_id),
+             (9,  14, 15, 4,  8, node1.tree_id),
+             (10, 17, 20, 3,  7, node1.tree_id),
+             (11, 18, 19, 4, 10, node1.tree_id),
 
-             (12,  1, 22, 1, None, 2),
-             (13,  2,  5, 2, 12, 2),
-             (14,  3,  4, 3, 13, 2),
-             (15,  6, 11, 2, 12, 2),
-             (16,  7,  8, 3, 15, 2),
-             (17,  9, 10, 3, 15, 2),
-             (18, 12, 21, 2, 12, 2),
-             (19, 13, 16, 3, 18, 2),
-             (20, 14, 15, 4, 19, 2),
-             (21, 17, 20, 3, 18, 2),
-             (22, 18, 19, 4, 21, 2)], self.result.all())  # flake8: noqa
+             (12,  1, 22, 1, None, node2.tree_id),
+             (13,  2,  5, 2, 12, node2.tree_id),
+             (14,  3,  4, 3, 13, node2.tree_id),
+             (15,  6, 11, 2, 12, node2.tree_id),
+             (16,  7,  8, 3, 15, node2.tree_id),
+             (17,  9, 10, 3, 15, node2.tree_id),
+             (18, 12, 21, 2, 12, node2.tree_id),
+             (19, 13, 16, 3, 18, node2.tree_id),
+             (20, 14, 15, 4, 19, node2.tree_id),
+             (21, 17, 20, 3, 18, node2.tree_id),
+             (22, 18, 19, 4, 21, node2.tree_id)], self.result.all())  # flake8: noqa

--- a/sqlalchemy_mptt/tests/cases/move_node.py
+++ b/sqlalchemy_mptt/tests/cases/move_node.py
@@ -40,12 +40,17 @@ class MoveBefore(object):
         """
         node4 = self.session.query(self.model)\
             .filter(self.model.get_pk_column() == 4).one()
-        node2 = self.session.query(self.model) \
+        node12 = self.session.query(self.model) \
             .filter(self.model.get_pk_column() == 12).one()
         node4.move_before(1)
 
         node1 = self.session.query(self.model) \
             .filter(self.model.get_pk_column() == 1).one()
+        node12 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
+        node4 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 4).one()
+
 
         #    id lft rgt lvl parent tree
         self.assertEqual(
@@ -63,17 +68,17 @@ class MoveBefore(object):
              (10, 11, 14, 3,  7, node1.tree_id),
              (11, 12, 13, 4, 10, node1.tree_id),
 
-             (12,  1, 22, 1, None, node2.tree_id),
-             (13,  2,  5, 2, 12, node2.tree_id),
-             (14,  3,  4, 3, 13, node2.tree_id),
-             (15,  6, 11, 2, 12, node2.tree_id),
-             (16,  7,  8, 3, 15, node2.tree_id),
-             (17,  9, 10, 3, 15, node2.tree_id),
-             (18, 12, 21, 2, 12, node2.tree_id),
-             (19, 13, 16, 3, 18, node2.tree_id),
-             (20, 14, 15, 4, 19, node2.tree_id),
-             (21, 17, 20, 3, 18, node2.tree_id),
-             (22, 18, 19, 4, 21, node2.tree_id)], self.result.all())  # flake8: noqa
+             (12,  1, 22, 1, None, node12.tree_id),
+             (13,  2,  5, 2, 12, node12.tree_id),
+             (14,  3,  4, 3, 13, node12.tree_id),
+             (15,  6, 11, 2, 12, node12.tree_id),
+             (16,  7,  8, 3, 15, node12.tree_id),
+             (17,  9, 10, 3, 15, node12.tree_id),
+             (18, 12, 21, 2, 12, node12.tree_id),
+             (19, 13, 16, 3, 18, node12.tree_id),
+             (20, 14, 15, 4, 19, node12.tree_id),
+             (21, 17, 20, 3, 18, node12.tree_id),
+             (22, 18, 19, 4, 21, node12.tree_id)], self.result.all())  # flake8: noqa
 
     def test_move_one_tree_before_another(self):
         """ For example move node(12) before node(1)

--- a/sqlalchemy_mptt/tests/cases/move_node.py
+++ b/sqlalchemy_mptt/tests/cases/move_node.py
@@ -38,36 +38,42 @@ class MoveBefore(object):
                 4                               8(9)9    12(11)13
 
         """
-        node = self.session.query(self.model)\
+        node4 = self.session.query(self.model)\
             .filter(self.model.get_pk_column() == 4).one()
-        node.move_before(1)
+        node2 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
+        node4.move_before(1)
+
+        node1 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 1).one()
+
         #    id lft rgt lvl parent tree
         self.assertEqual(
-            [(1,   1, 16, 1, None, 2),
-             (2,   2,  5, 2,  1, 2),
-             (3,   3,  4, 3,  2, 2),
+            [(1,   1, 16, 1, None, node1.tree_id),
+             (2,   2,  5, 2,  1, node1.tree_id),
+             (3,   3,  4, 3,  2, node1.tree_id),
 
-             (4,   1,  6, 1,  None, 1),
-             (5,   2,  3, 2,  4, 1),
-             (6,   4,  5, 2,  4, 1),
+             (4,   1,  6, 1,  None, node4.tree_id),
+             (5,   2,  3, 2,  4, node4.tree_id),
+             (6,   4,  5, 2,  4, node4.tree_id),
 
-             (7,   6, 15, 2,  1, 2),
-             (8,   7, 10, 3,  7, 2),
-             (9,   8,  9, 4,  8, 2),
-             (10, 11, 14, 3,  7, 2),
-             (11, 12, 13, 4, 10, 2),
+             (7,   6, 15, 2,  1, node1.tree_id),
+             (8,   7, 10, 3,  7, node1.tree_id),
+             (9,   8,  9, 4,  8, node1.tree_id),
+             (10, 11, 14, 3,  7, node1.tree_id),
+             (11, 12, 13, 4, 10, node1.tree_id),
 
-             (12,  1, 22, 1, None, 3),
-             (13,  2,  5, 2, 12, 3),
-             (14,  3,  4, 3, 13, 3),
-             (15,  6, 11, 2, 12, 3),
-             (16,  7,  8, 3, 15, 3),
-             (17,  9, 10, 3, 15, 3),
-             (18, 12, 21, 2, 12, 3),
-             (19, 13, 16, 3, 18, 3),
-             (20, 14, 15, 4, 19, 3),
-             (21, 17, 20, 3, 18, 3),
-             (22, 18, 19, 4, 21, 3)], self.result.all())  # flake8: noqa
+             (12,  1, 22, 1, None, node2.tree_id),
+             (13,  2,  5, 2, 12, node2.tree_id),
+             (14,  3,  4, 3, 13, node2.tree_id),
+             (15,  6, 11, 2, 12, node2.tree_id),
+             (16,  7,  8, 3, 15, node2.tree_id),
+             (17,  9, 10, 3, 15, node2.tree_id),
+             (18, 12, 21, 2, 12, node2.tree_id),
+             (19, 13, 16, 3, 18, node2.tree_id),
+             (20, 14, 15, 4, 19, node2.tree_id),
+             (21, 17, 20, 3, 18, node2.tree_id),
+             (22, 18, 19, 4, 21, node2.tree_id)], self.result.all())  # flake8: noqa
 
     def test_move_one_tree_before_another(self):
         """ For example move node(12) before node(1)
@@ -98,33 +104,35 @@ class MoveBefore(object):
                 4                                  14(20)15   18(22)19
 
         """
-        node = self.session.query(self.model)\
+        node2 = self.session.query(self.model)\
             .filter(self.model.get_pk_column() == 12).one()
-        node.move_before("1")
+        node1 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 1).one()
+        node2.move_before("1")
         #                 id lft rgt lvl parent tree
-        self.assertEqual([(1,   1, 22, 1, None, 2),
-                          (2,   2,  5, 2,  1, 2),
-                          (3,   3,  4, 3,  2, 2),
-                          (4,   6, 11, 2,  1, 2),
-                          (5,   7,  8, 3,  4, 2),
-                          (6,   9, 10, 3,  4, 2),
-                          (7,  12, 21, 2,  1, 2),
-                          (8,  13, 16, 3,  7, 2),
-                          (9,  14, 15, 4,  8, 2),
-                          (10, 17, 20, 3,  7, 2),
-                          (11, 18, 19, 4, 10, 2),
+        self.assertEqual([(1,   1, 22, 1, None, node1.tree_id),
+                          (2,   2,  5, 2,  1, node1.tree_id),
+                          (3,   3,  4, 3,  2, node1.tree_id),
+                          (4,   6, 11, 2,  1, node1.tree_id),
+                          (5,   7,  8, 3,  4, node1.tree_id),
+                          (6,   9, 10, 3,  4, node1.tree_id),
+                          (7,  12, 21, 2,  1, node1.tree_id),
+                          (8,  13, 16, 3,  7, node1.tree_id),
+                          (9,  14, 15, 4,  8, node1.tree_id),
+                          (10, 17, 20, 3,  7, node1.tree_id),
+                          (11, 18, 19, 4, 10, node1.tree_id),
 
-                          (12,  1, 22, 1, None, 1),
-                          (13,  2,  5, 2, 12, 1),
-                          (14,  3,  4, 3, 13, 1),
-                          (15,  6, 11, 2, 12, 1),
-                          (16,  7,  8, 3, 15, 1),
-                          (17,  9, 10, 3, 15, 1),
-                          (18, 12, 21, 2, 12, 1),
-                          (19, 13, 16, 3, 18, 1),
-                          (20, 14, 15, 4, 19, 1),
-                          (21, 17, 20, 3, 18, 1),
-                          (22, 18, 19, 4, 21, 1)], self.result.all())
+                          (12,  1, 22, 1, None, node2.tree_id),
+                          (13,  2,  5, 2, 12, node2.tree_id),
+                          (14,  3,  4, 3, 13, node2.tree_id),
+                          (15,  6, 11, 2, 12, node2.tree_id),
+                          (16,  7,  8, 3, 15, node2.tree_id),
+                          (17,  9, 10, 3, 15, node2.tree_id),
+                          (18, 12, 21, 2, 12, node2.tree_id),
+                          (19, 13, 16, 3, 18, node2.tree_id),
+                          (20, 14, 15, 4, 19, node2.tree_id),
+                          (21, 17, 20, 3, 18, node2.tree_id),
+                          (22, 18, 19, 4, 21, node2.tree_id)], self.result.all())
 
     def test_move_before_function(self):
         """ For example move node(8) before node(4)
@@ -157,30 +165,34 @@ class MoveBefore(object):
         node = self.session.query(self.model)\
             .filter(self.model.get_pk_column() == 8).one()
         node.move_before("4")
+        node1 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 1).one()
+        node12 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
         #                 id lft rgt lvl parent tree
-        self.assertEqual([(1,   1, 22, 1, None, 1),
-                          (2,   2,  5, 2,  1, 1),
-                          (3,   3,  4, 3,  2, 1),
-                          (4,  10, 15, 2,  1, 1),
-                          (5,  11, 12, 3,  4, 1),
-                          (6,  13, 14, 3,  4, 1),
-                          (7,  16, 21, 2,  1, 1),
-                          (8,   6,  9, 2,  1, 1),
-                          (9,   7,  8, 3,  8, 1),
-                          (10, 17, 20, 3,  7, 1),
-                          (11, 18, 19, 4, 10, 1),
+        self.assertEqual([(1,   1, 22, 1, None, node1.tree_id),
+                          (2,   2,  5, 2,  1, node1.tree_id),
+                          (3,   3,  4, 3,  2, node1.tree_id),
+                          (4,  10, 15, 2,  1, node1.tree_id),
+                          (5,  11, 12, 3,  4, node1.tree_id),
+                          (6,  13, 14, 3,  4, node1.tree_id),
+                          (7,  16, 21, 2,  1, node1.tree_id),
+                          (8,   6,  9, 2,  1, node1.tree_id),
+                          (9,   7,  8, 3,  8, node1.tree_id),
+                          (10, 17, 20, 3,  7, node1.tree_id),
+                          (11, 18, 19, 4, 10, node1.tree_id),
 
-                          (12,  1, 22, 1, None, 2),
-                          (13,  2,  5, 2, 12, 2),
-                          (14,  3,  4, 3, 13, 2),
-                          (15,  6, 11, 2, 12, 2),
-                          (16,  7,  8, 3, 15, 2),
-                          (17,  9, 10, 3, 15, 2),
-                          (18, 12, 21, 2, 12, 2),
-                          (19, 13, 16, 3, 18, 2),
-                          (20, 14, 15, 4, 19, 2),
-                          (21, 17, 20, 3, 18, 2),
-                          (22, 18, 19, 4, 21, 2)], self.result.all())
+                          (12,  1, 22, 1, None, node12.tree_id),
+                          (13,  2,  5, 2, 12, node12.tree_id),
+                          (14,  3,  4, 3, 13, node12.tree_id),
+                          (15,  6, 11, 2, 12, node12.tree_id),
+                          (16,  7,  8, 3, 15, node12.tree_id),
+                          (17,  9, 10, 3, 15, node12.tree_id),
+                          (18, 12, 21, 2, 12, node12.tree_id),
+                          (19, 13, 16, 3, 18, node12.tree_id),
+                          (20, 14, 15, 4, 19, node12.tree_id),
+                          (21, 17, 20, 3, 18, node12.tree_id),
+                          (22, 18, 19, 4, 21, node12.tree_id)], self.result.all())
 
     def test_move_one_tree_before_other_tree(self):
         self.fixture.add(
@@ -193,135 +205,153 @@ class MoveBefore(object):
         node = self.session.query(self.model).\
             filter(self.model.get_pk_column() == 12).one()
         node.move_before("1")
+        node1 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 1).one()
+        node12 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
+        node23 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 23).one()
         self.assertEqual(
             self.result.all(),
             [
                 #  id lft rgt lvl parent tree
-                (1,   1, 22, 1, None, 2),
-                (2,   2,  5, 2,  1, 2),
-                (3,   3,  4, 3,  2, 2),
-                (4,   6, 11, 2,  1, 2),
-                (5,   7,  8, 3,  4, 2),
-                (6,   9, 10, 3,  4, 2),
-                (7,  12, 21, 2,  1, 2),
-                (8,  13, 16, 3,  7, 2),
-                (9,  14, 15, 4,  8, 2),
-                (10, 17, 20, 3,  7, 2),
-                (11, 18, 19, 4, 10, 2),
+                (1,   1, 22, 1, None, node1.tree_id),
+                (2,   2,  5, 2,  1, node1.tree_id),
+                (3,   3,  4, 3,  2, node1.tree_id),
+                (4,   6, 11, 2,  1, node1.tree_id),
+                (5,   7,  8, 3,  4, node1.tree_id),
+                (6,   9, 10, 3,  4, node1.tree_id),
+                (7,  12, 21, 2,  1, node1.tree_id),
+                (8,  13, 16, 3,  7, node1.tree_id),
+                (9,  14, 15, 4,  8, node1.tree_id),
+                (10, 17, 20, 3,  7, node1.tree_id),
+                (11, 18, 19, 4, 10, node1.tree_id),
 
-                (12,  1, 22, 1, None, 1),
-                (13,  2,  5, 2, 12, 1),
-                (14,  3,  4, 3, 13, 1),
-                (15,  6, 11, 2, 12, 1),
-                (16,  7,  8, 3, 15, 1),
-                (17,  9, 10, 3, 15, 1),
-                (18, 12, 21, 2, 12, 1),
-                (19, 13, 16, 3, 18, 1),
-                (20, 14, 15, 4, 19, 1),
-                (21, 17, 20, 3, 18, 1),
-                (22, 18, 19, 4, 21, 1),
+                (12,  1, 22, 1, None, node12.tree_id),
+                (13,  2,  5, 2, 12, node12.tree_id),
+                (14,  3,  4, 3, 13, node12.tree_id),
+                (15,  6, 11, 2, 12, node12.tree_id),
+                (16,  7,  8, 3, 15, node12.tree_id),
+                (17,  9, 10, 3, 15, node12.tree_id),
+                (18, 12, 21, 2, 12, node12.tree_id),
+                (19, 13, 16, 3, 18, node12.tree_id),
+                (20, 14, 15, 4, 19, node12.tree_id),
+                (21, 17, 20, 3, 18, node12.tree_id),
+                (22, 18, 19, 4, 21, node12.tree_id),
 
-                (23,  1, 22, 1, None, 4),
-                (24,  2,  5, 2, 23, 4),
-                (25,  3,  4, 3, 24, 4),
-                (26,  6, 11, 2, 23, 4),
-                (27,  7,  8, 3, 26, 4),
-                (28,  9, 10, 3, 26, 4),
-                (29, 12, 21, 2, 23, 4),
-                (30, 13, 16, 3, 29, 4),
-                (31, 14, 15, 4, 30, 4),
-                (32, 17, 20, 3, 29, 4),
-                (33, 18, 19, 4, 32, 4)
+                (23,  1, 22, 1, None, node23.tree_id),
+                (24,  2,  5, 2, 23, node23.tree_id),
+                (25,  3,  4, 3, 24, node23.tree_id),
+                (26,  6, 11, 2, 23, node23.tree_id),
+                (27,  7,  8, 3, 26, node23.tree_id),
+                (28,  9, 10, 3, 26, node23.tree_id),
+                (29, 12, 21, 2, 23, node23.tree_id),
+                (30, 13, 16, 3, 29, node23.tree_id),
+                (31, 14, 15, 4, 30, node23.tree_id),
+                (32, 17, 20, 3, 29, node23.tree_id),
+                (33, 18, 19, 4, 32, node23.tree_id)
             ])
 
         node = self.session.query(self.model).\
             filter(self.model.get_pk_column() == 23).one()
         node.move_before("1")
-
+        node1 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 1).one()
+        node12 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
+        node23 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 23).one()
+        
         self.assertEqual(
             self.result.all(),
             [
                 #  id lft rgt lvl parent tree
-                (1,   1, 22, 1, None, 3),
-                (2,   2,  5, 2,  1, 3),
-                (3,   3,  4, 3,  2, 3),
-                (4,   6, 11, 2,  1, 3),
-                (5,   7,  8, 3,  4, 3),
-                (6,   9, 10, 3,  4, 3),
-                (7,  12, 21, 2,  1, 3),
-                (8,  13, 16, 3,  7, 3),
-                (9,  14, 15, 4,  8, 3),
-                (10, 17, 20, 3,  7, 3),
-                (11, 18, 19, 4, 10, 3),
+                (1,   1, 22, 1, None, node1.tree_id),
+                (2,   2,  5, 2,  1, node1.tree_id),
+                (3,   3,  4, 3,  2, node1.tree_id),
+                (4,   6, 11, 2,  1, node1.tree_id),
+                (5,   7,  8, 3,  4, node1.tree_id),
+                (6,   9, 10, 3,  4, node1.tree_id),
+                (7,  12, 21, 2,  1, node1.tree_id),
+                (8,  13, 16, 3,  7, node1.tree_id),
+                (9,  14, 15, 4,  8, node1.tree_id),
+                (10, 17, 20, 3,  7, node1.tree_id),
+                (11, 18, 19, 4, 10, node1.tree_id),
 
-                (12,  1, 22, 1, None, 1),
-                (13,  2,  5, 2, 12, 1),
-                (14,  3,  4, 3, 13, 1),
-                (15,  6, 11, 2, 12, 1),
-                (16,  7,  8, 3, 15, 1),
-                (17,  9, 10, 3, 15, 1),
-                (18, 12, 21, 2, 12, 1),
-                (19, 13, 16, 3, 18, 1),
-                (20, 14, 15, 4, 19, 1),
-                (21, 17, 20, 3, 18, 1),
-                (22, 18, 19, 4, 21, 1),
+                (12,  1, 22, 1, None, node12.tree_id),
+                (13,  2,  5, 2, 12, node12.tree_id),
+                (14,  3,  4, 3, 13, node12.tree_id),
+                (15,  6, 11, 2, 12, node12.tree_id),
+                (16,  7,  8, 3, 15, node12.tree_id),
+                (17,  9, 10, 3, 15, node12.tree_id),
+                (18, 12, 21, 2, 12, node12.tree_id),
+                (19, 13, 16, 3, 18, node12.tree_id),
+                (20, 14, 15, 4, 19, node12.tree_id),
+                (21, 17, 20, 3, 18, node12.tree_id),
+                (22, 18, 19, 4, 21, node12.tree_id),
 
-                (23,  1, 22, 1, None, 2),
-                (24,  2,  5, 2, 23, 2),
-                (25,  3,  4, 3, 24, 2),
-                (26,  6, 11, 2, 23, 2),
-                (27,  7,  8, 3, 26, 2),
-                (28,  9, 10, 3, 26, 2),
-                (29, 12, 21, 2, 23, 2),
-                (30, 13, 16, 3, 29, 2),
-                (31, 14, 15, 4, 30, 2),
-                (32, 17, 20, 3, 29, 2),
-                (33, 18, 19, 4, 32, 2)
+                (23,  1, 22, 1, None, node23.tree_id),
+                (24,  2,  5, 2, 23, node23.tree_id),
+                (25,  3,  4, 3, 24, node23.tree_id),
+                (26,  6, 11, 2, 23, node23.tree_id),
+                (27,  7,  8, 3, 26, node23.tree_id),
+                (28,  9, 10, 3, 26, node23.tree_id),
+                (29, 12, 21, 2, 23, node23.tree_id),
+                (30, 13, 16, 3, 29, node23.tree_id),
+                (31, 14, 15, 4, 30, node23.tree_id),
+                (32, 17, 20, 3, 29, node23.tree_id),
+                (33, 18, 19, 4, 32, node23.tree_id)
             ])
 
         node = self.session.query(self.model).\
             filter(self.model.get_pk_column() == 1).one()
         node.move_before("12")
-
+        node1 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 1).one()
+        node12 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
+        node23 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 23).one()
+        
         self.assertEqual(
             self.result.all(),
             [
                 #  id lft rgt lvl parent tree
-                (1,   1, 22, 1, None, 1),
-                (2,   2,  5, 2,  1, 1),
-                (3,   3,  4, 3,  2, 1),
-                (4,   6, 11, 2,  1, 1),
-                (5,   7,  8, 3,  4, 1),
-                (6,   9, 10, 3,  4, 1),
-                (7,  12, 21, 2,  1, 1),
-                (8,  13, 16, 3,  7, 1),
-                (9,  14, 15, 4,  8, 1),
-                (10, 17, 20, 3,  7, 1),
-                (11, 18, 19, 4, 10, 1),
+                (1,   1, 22, 1, None, node1.tree_id),
+                (2,   2,  5, 2,  1, node1.tree_id),
+                (3,   3,  4, 3,  2, node1.tree_id),
+                (4,   6, 11, 2,  1, node1.tree_id),
+                (5,   7,  8, 3,  4, node1.tree_id),
+                (6,   9, 10, 3,  4, node1.tree_id),
+                (7,  12, 21, 2,  1, node1.tree_id),
+                (8,  13, 16, 3,  7, node1.tree_id),
+                (9,  14, 15, 4,  8, node1.tree_id),
+                (10, 17, 20, 3,  7, node1.tree_id),
+                (11, 18, 19, 4, 10, node1.tree_id),
 
-                (12,  1, 22, 1, None, 2),
-                (13,  2,  5, 2, 12, 2),
-                (14,  3,  4, 3, 13, 2),
-                (15,  6, 11, 2, 12, 2),
-                (16,  7,  8, 3, 15, 2),
-                (17,  9, 10, 3, 15, 2),
-                (18, 12, 21, 2, 12, 2),
-                (19, 13, 16, 3, 18, 2),
-                (20, 14, 15, 4, 19, 2),
-                (21, 17, 20, 3, 18, 2),
-                (22, 18, 19, 4, 21, 2),
+                (12,  1, 22, 1, None, node12.tree_id),
+                (13,  2,  5, 2, 12, node12.tree_id),
+                (14,  3,  4, 3, 13, node12.tree_id),
+                (15,  6, 11, 2, 12, node12.tree_id),
+                (16,  7,  8, 3, 15, node12.tree_id),
+                (17,  9, 10, 3, 15, node12.tree_id),
+                (18, 12, 21, 2, 12, node12.tree_id),
+                (19, 13, 16, 3, 18, node12.tree_id),
+                (20, 14, 15, 4, 19, node12.tree_id),
+                (21, 17, 20, 3, 18, node12.tree_id),
+                (22, 18, 19, 4, 21, node12.tree_id),
 
-                (23,  1, 22, 1, None, 3),
-                (24,  2,  5, 2, 23, 3),
-                (25,  3,  4, 3, 24, 3),
-                (26,  6, 11, 2, 23, 3),
-                (27,  7,  8, 3, 26, 3),
-                (28,  9, 10, 3, 26, 3),
-                (29, 12, 21, 2, 23, 3),
-                (30, 13, 16, 3, 29, 3),
-                (31, 14, 15, 4, 30, 3),
-                (32, 17, 20, 3, 29, 3),
-                (33, 18, 19, 4, 32, 3)
+                (23,  1, 22, 1, None, node23.tree_id),
+                (24,  2,  5, 2, 23, node23.tree_id),
+                (25,  3,  4, 3, 24, node23.tree_id),
+                (26,  6, 11, 2, 23, node23.tree_id),
+                (27,  7,  8, 3, 26, node23.tree_id),
+                (28,  9, 10, 3, 26, node23.tree_id),
+                (29, 12, 21, 2, 23, node23.tree_id),
+                (30, 13, 16, 3, 29, node23.tree_id),
+                (31, 14, 15, 4, 30, node23.tree_id),
+                (32, 17, 20, 3, 29, node23.tree_id),
+                (33, 18, 19, 4, 32, node23.tree_id)
             ])
 
     def test_move_before_to_other_tree(self):
@@ -355,32 +385,36 @@ class MoveBefore(object):
         node = self.session.query(self.model)\
             .filter(self.model.get_pk_column() == 8).one()
         node.move_before("15")
+        node1 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 1).one()
+        node12 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
         #                 id lft rgt lvl parent tree
-        self.assertEqual([(1,   1, 18, 1, None, 1),
-                          (2,   2,  5, 2,  1, 1),
-                          (3,   3,  4, 3,  2, 1),
-                          (4,   6, 11, 2,  1, 1),
-                          (5,   7,  8, 3,  4, 1),
-                          (6,   9, 10, 3,  4, 1),
-                          (7,  12, 17, 2,  1, 1),
+        self.assertEqual([(1,   1, 18, 1, None, node1.tree_id),
+                          (2,   2,  5, 2,  1, node1.tree_id),
+                          (3,   3,  4, 3,  2, node1.tree_id),
+                          (4,   6, 11, 2,  1, node1.tree_id),
+                          (5,   7,  8, 3,  4, node1.tree_id),
+                          (6,   9, 10, 3,  4, node1.tree_id),
+                          (7,  12, 17, 2,  1, node1.tree_id),
 
-                          (8,   6,  9, 2,  12, 2),
-                          (9,   7,  8, 3,   8, 2),
+                          (8,   6,  9, 2,  12, node12.tree_id),
+                          (9,   7,  8, 3,   8, node12.tree_id),
 
-                          (10, 13, 16, 3,  7, 1),
-                          (11, 14, 15, 4, 10, 1),
+                          (10, 13, 16, 3,  7, node1.tree_id),
+                          (11, 14, 15, 4, 10, node1.tree_id),
 
-                          (12,  1, 26, 1, None, 2),
-                          (13,  2,  5, 2, 12, 2),
-                          (14,  3,  4, 3, 13, 2),
-                          (15, 10, 15, 2, 12, 2),
-                          (16, 11, 12, 3, 15, 2),
-                          (17, 13, 14, 3, 15, 2),
-                          (18, 16, 25, 2, 12, 2),
-                          (19, 17, 20, 3, 18, 2),
-                          (20, 18, 19, 4, 19, 2),
-                          (21, 21, 24, 3, 18, 2),
-                          (22, 22, 23, 4, 21, 2)], self.result.all())
+                          (12,  1, 26, 1, None, node12.tree_id),
+                          (13,  2,  5, 2, 12, node12.tree_id),
+                          (14,  3,  4, 3, 13, node12.tree_id),
+                          (15, 10, 15, 2, 12, node12.tree_id),
+                          (16, 11, 12, 3, 15, node12.tree_id),
+                          (17, 13, 14, 3, 15, node12.tree_id),
+                          (18, 16, 25, 2, 12, node12.tree_id),
+                          (19, 17, 20, 3, 18, node12.tree_id),
+                          (20, 18, 19, 4, 19, node12.tree_id),
+                          (21, 21, 24, 3, 18, node12.tree_id),
+                          (22, 22, 23, 4, 21, node12.tree_id)], self.result.all())
 
 
 class MoveAfter(object):
@@ -416,30 +450,34 @@ class MoveAfter(object):
         node = self.session.query(self.model)\
             .filter(self.model.get_pk_column() == 8).one()
         node.move_after("5")
+        node1 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 1).one()
+        node12 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
         #                 id lft rgt lvl parent tree
-        self.assertEqual([(1,   1, 22, 1, None, 1),
-                          (2,   2,  5, 2,  1, 1),
-                          (3,   3,  4, 3,  2, 1),
-                          (4,   6, 15, 2,  1, 1),
-                          (5,   7,  8, 3,  4, 1),
-                          (6,  13, 14, 3,  4, 1),
-                          (7,  16, 21, 2,  1, 1),
-                          (8,   9, 12, 3,  4, 1),
-                          (9,  10, 11, 4,  8, 1),
-                          (10, 17, 20, 3,  7, 1),
-                          (11, 18, 19, 4, 10, 1),
+        self.assertEqual([(1,   1, 22, 1, None, node1.tree_id),
+                          (2,   2,  5, 2,  1, node1.tree_id),
+                          (3,   3,  4, 3,  2, node1.tree_id),
+                          (4,   6, 15, 2,  1, node1.tree_id),
+                          (5,   7,  8, 3,  4, node1.tree_id),
+                          (6,  13, 14, 3,  4, node1.tree_id),
+                          (7,  16, 21, 2,  1, node1.tree_id),
+                          (8,   9, 12, 3,  4, node1.tree_id),
+                          (9,  10, 11, 4,  8, node1.tree_id),
+                          (10, 17, 20, 3,  7, node1.tree_id),
+                          (11, 18, 19, 4, 10, node1.tree_id),
 
-                          (12,  1, 22, 1, None, 2),
-                          (13,  2,  5, 2, 12, 2),
-                          (14,  3,  4, 3, 13, 2),
-                          (15,  6, 11, 2, 12, 2),
-                          (16,  7,  8, 3, 15, 2),
-                          (17,  9, 10, 3, 15, 2),
-                          (18, 12, 21, 2, 12, 2),
-                          (19, 13, 16, 3, 18, 2),
-                          (20, 14, 15, 4, 19, 2),
-                          (21, 17, 20, 3, 18, 2),
-                          (22, 18, 19, 4, 21, 2)], self.result.all())
+                          (12,  1, 22, 1, None, node12.tree_id),
+                          (13,  2,  5, 2, 12, node12.tree_id),
+                          (14,  3,  4, 3, 13, node12.tree_id),
+                          (15,  6, 11, 2, 12, node12.tree_id),
+                          (16,  7,  8, 3, 15, node12.tree_id),
+                          (17,  9, 10, 3, 15, node12.tree_id),
+                          (18, 12, 21, 2, 12, node12.tree_id),
+                          (19, 13, 16, 3, 18, node12.tree_id),
+                          (20, 14, 15, 4, 19, node12.tree_id),
+                          (21, 17, 20, 3, 18, node12.tree_id),
+                          (22, 18, 19, 4, 21, node12.tree_id)], self.result.all())
 
     def test_move_to_toplevel_where_much_trees_from_right_side(self):
         """ Move 20 after 1
@@ -477,36 +515,50 @@ class MoveAfter(object):
         node = self.session.query(self.model)\
             .filter(self.model.get_pk_column() == 15).one()
         node.move_after("1")
+        node1 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 1).one()
+        node12 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
+        node15 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 15).one()
         #                 id lft rgt lvl parent tree
-        self.assertEqual([(1,   1, 22, 1, None, 1),
-                          (2,   2,  5, 2,  1, 1),
-                          (3,   3,  4, 3,  2, 1),
-                          (4,   6, 11, 2,  1, 1),
-                          (5,   7,  8, 3,  4, 1),
-                          (6,   9, 10, 3,  4, 1),
-                          (7,  12, 21, 2,  1, 1),
-                          (8,  13, 16, 3,  7, 1),
-                          (9,  14, 15, 4,  8, 1),
-                          (10, 17, 20, 3,  7, 1),
-                          (11, 18, 19, 4, 10, 1),
+        self.assertEqual([(1,   1, 22, 1, None, node1.tree_id),
+                          (2,   2,  5, 2,  1, node1.tree_id),
+                          (3,   3,  4, 3,  2, node1.tree_id),
+                          (4,   6, 11, 2,  1, node1.tree_id),
+                          (5,   7,  8, 3,  4, node1.tree_id),
+                          (6,   9, 10, 3,  4, node1.tree_id),
+                          (7,  12, 21, 2,  1, node1.tree_id),
+                          (8,  13, 16, 3,  7, node1.tree_id),
+                          (9,  14, 15, 4,  8, node1.tree_id),
+                          (10, 17, 20, 3,  7, node1.tree_id),
+                          (11, 18, 19, 4, 10, node1.tree_id),
 
-                          (12, 1, 16, 1, None, 3),
-                          (13, 2,  5, 2, 12,   3),
-                          (14, 3,  4, 3, 13,   3),
+                          (12, 1, 16, 1, None, node12.tree_id),
+                          (13, 2,  5, 2, 12,   node12.tree_id),
+                          (14, 3,  4, 3, 13,   node12.tree_id),
 
-                          (15, 1, 6, 1, None, 2),
-                          (16, 2, 3, 2, 15,   2),
-                          (17, 4, 5, 2, 15,   2),
+                          (15, 1, 6, 1, None, node15.tree_id),
+                          (16, 2, 3, 2, 15,   node15.tree_id),
+                          (17, 4, 5, 2, 15,   node15.tree_id),
 
-                          (18,  6, 15, 2, 12, 3),
-                          (19,  7, 10, 3, 18, 3),
-                          (20,  8,  9, 4, 19, 3),
-                          (21, 11, 14, 3, 18, 3),
-                          (22, 12, 13, 4, 21, 3)], self.result.all())
+                          (18,  6, 15, 2, 12, node12.tree_id),
+                          (19,  7, 10, 3, 18, node12.tree_id),
+                          (20,  8,  9, 4, 19, node12.tree_id),
+                          (21, 11, 14, 3, 18, node12.tree_id),
+                          (22, 12, 13, 4, 21, node12.tree_id)], self.result.all())
 
         node = self.session.query(self.model)\
             .filter(self.model.get_pk_column() == 20).one()
         node.move_after("1")
+        node1 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 1).one()
+        node12 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
+        node15 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 15).one()
+        node20 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 20).one()
         """ level           tree_id = 1
             1                    1(1)22
                     _______________|___________________
@@ -537,31 +589,31 @@ class MoveAfter(object):
 
         """
         #                 id lft rgt lvl parent tree
-        self.assertEqual([(1,   1, 22, 1, None, 1),
-                          (2,   2,  5, 2,  1, 1),
-                          (3,   3,  4, 3,  2, 1),
-                          (4,   6, 11, 2,  1, 1),
-                          (5,   7,  8, 3,  4, 1),
-                          (6,   9, 10, 3,  4, 1),
-                          (7,  12, 21, 2,  1, 1),
-                          (8,  13, 16, 3,  7, 1),
-                          (9,  14, 15, 4,  8, 1),
-                          (10, 17, 20, 3,  7, 1),
-                          (11, 18, 19, 4, 10, 1),
+        self.assertEqual([(1,   1, 22, 1, None, node1.tree_id),
+                          (2,   2,  5, 2,  1, node1.tree_id),
+                          (3,   3,  4, 3,  2, node1.tree_id),
+                          (4,   6, 11, 2,  1, node1.tree_id),
+                          (5,   7,  8, 3,  4, node1.tree_id),
+                          (6,   9, 10, 3,  4, node1.tree_id),
+                          (7,  12, 21, 2,  1, node1.tree_id),
+                          (8,  13, 16, 3,  7, node1.tree_id),
+                          (9,  14, 15, 4,  8, node1.tree_id),
+                          (10, 17, 20, 3,  7, node1.tree_id),
+                          (11, 18, 19, 4, 10, node1.tree_id),
 
-                          (12, 1, 14, 1, None, 4),
-                          (13, 2,  5, 2, 12,   4),
-                          (14, 3,  4, 3, 13,   4),
+                          (12, 1, 14, 1, None, node12.tree_id),
+                          (13, 2,  5, 2, 12,   node12.tree_id),
+                          (14, 3,  4, 3, 13,   node12.tree_id),
 
-                          (15, 1, 6, 1, None, 3),
-                          (16, 2, 3, 2, 15,   3),
-                          (17, 4, 5, 2, 15,   3),
+                          (15, 1, 6, 1, None, node15.tree_id),
+                          (16, 2, 3, 2, 15,   node15.tree_id),
+                          (17, 4, 5, 2, 15,   node15.tree_id),
 
-                          (18,  6, 13, 2, 12, 4),
-                          (19,  7,  8, 3, 18, 4),
-                          (20,  1,  2, 1, None, 2),
-                          (21,  9, 12, 3, 18, 4),
-                          (22, 10, 11, 4, 21, 4)], self.result.all())
+                          (18,  6, 13, 2, 12, node12.tree_id),
+                          (19,  7,  8, 3, 18, node12.tree_id),
+                          (20,  1,  2, 1, None, node20.tree_id),
+                          (21,  9, 12, 3, 18, node12.tree_id),
+                          (22, 10, 11, 4, 21, node12.tree_id)], self.result.all())
 
     def test_move_to_toplevel(self):
         """ Move node(8) to top level after node(1)
@@ -594,32 +646,38 @@ class MoveAfter(object):
         node = self.session.query(self.model)\
             .filter(self.model.get_pk_column() == 8).one()
         node.move_after("1")
+        node1 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 1).one()
+        node8 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 8).one()
+        node12 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
         #                 id lft rgt lvl parent tree
-        self.assertEqual([(1,   1, 18, 1, None, 1),
-                          (2,   2,  5, 2,  1, 1),
-                          (3,   3,  4, 3,  2, 1),
-                          (4,   6, 11, 2,  1, 1),
-                          (5,   7,  8, 3,  4, 1),
-                          (6,   9, 10, 3,  4, 1),
-                          (7,  12, 17, 2,  1, 1),
+        self.assertEqual([(1,   1, 18, 1, None, node1.tree_id),
+                          (2,   2,  5, 2,  1, node1.tree_id),
+                          (3,   3,  4, 3,  2, node1.tree_id),
+                          (4,   6, 11, 2,  1, node1.tree_id),
+                          (5,   7,  8, 3,  4, node1.tree_id),
+                          (6,   9, 10, 3,  4, node1.tree_id),
+                          (7,  12, 17, 2,  1, node1.tree_id),
 
-                          (8,   1,  4, 1, None, 2),
-                          (9,   2,  3, 2,  8, 2),
+                          (8,   1,  4, 1, None, node8.tree_id),
+                          (9,   2,  3, 2,  8, node8.tree_id),
 
-                          (10, 13, 16, 3,  7, 1),
-                          (11, 14, 15, 4, 10, 1),
+                          (10, 13, 16, 3,  7, node1.tree_id),
+                          (11, 14, 15, 4, 10, node1.tree_id),
 
-                          (12,  1, 22, 1, None, 3),
-                          (13,  2,  5, 2, 12, 3),
-                          (14,  3,  4, 3, 13, 3),
-                          (15,  6, 11, 2, 12, 3),
-                          (16,  7,  8, 3, 15, 3),
-                          (17,  9, 10, 3, 15, 3),
-                          (18, 12, 21, 2, 12, 3),
-                          (19, 13, 16, 3, 18, 3),
-                          (20, 14, 15, 4, 19, 3),
-                          (21, 17, 20, 3, 18, 3),
-                          (22, 18, 19, 4, 21, 3)], self.result.all())
+                          (12,  1, 22, 1, None, node12.tree_id),
+                          (13,  2,  5, 2, 12, node12.tree_id),
+                          (14,  3,  4, 3, 13, node12.tree_id),
+                          (15,  6, 11, 2, 12, node12.tree_id),
+                          (16,  7,  8, 3, 15, node12.tree_id),
+                          (17,  9, 10, 3, 15, node12.tree_id),
+                          (18, 12, 21, 2, 12, node12.tree_id),
+                          (19, 13, 16, 3, 18, node12.tree_id),
+                          (20, 14, 15, 4, 19, node12.tree_id),
+                          (21, 17, 20, 3, 18, node12.tree_id),
+                          (22, 18, 19, 4, 21, node12.tree_id)], self.result.all())
 
     def test_move_to_toplevel2(self):
         """ Move node(8) to top level after node(1)
@@ -654,32 +712,38 @@ class MoveAfter(object):
             .filter(self.model.get_pk_column() == 8).one()
         node.parent_id = None
         self.session.add(node)
+        node1 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 1).one()
+        node8 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 8).one()
+        node12 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
         #                 id lft rgt lvl parent tree
-        self.assertEqual([(1,   1, 18, 1, None, 1),
-                          (2,   2,  5, 2,  1, 1),
-                          (3,   3,  4, 3,  2, 1),
-                          (4,   6, 11, 2,  1, 1),
-                          (5,   7,  8, 3,  4, 1),
-                          (6,   9, 10, 3,  4, 1),
-                          (7,  12, 17, 2,  1, 1),
+        self.assertEqual([(1,   1, 18, 1, None, node1.tree_id),
+                          (2,   2,  5, 2,  1, node1.tree_id),
+                          (3,   3,  4, 3,  2, node1.tree_id),
+                          (4,   6, 11, 2,  1, node1.tree_id),
+                          (5,   7,  8, 3,  4, node1.tree_id),
+                          (6,   9, 10, 3,  4, node1.tree_id),
+                          (7,  12, 17, 2,  1, node1.tree_id),
 
-                          (8,   1,  4, 1, None, 3),
-                          (9,   2,  3, 2,  8, 3),
+                          (8,   1,  4, 1, None, node8.tree_id),
+                          (9,   2,  3, 2,  8, node8.tree_id),
 
-                          (10, 13, 16, 3,  7, 1),
-                          (11, 14, 15, 4, 10, 1),
+                          (10, 13, 16, 3,  7, node1.tree_id),
+                          (11, 14, 15, 4, 10, node1.tree_id),
 
-                          (12,  1, 22, 1, None, 2),
-                          (13,  2,  5, 2, 12, 2),
-                          (14,  3,  4, 3, 13, 2),
-                          (15,  6, 11, 2, 12, 2),
-                          (16,  7,  8, 3, 15, 2),
-                          (17,  9, 10, 3, 15, 2),
-                          (18, 12, 21, 2, 12, 2),
-                          (19, 13, 16, 3, 18, 2),
-                          (20, 14, 15, 4, 19, 2),
-                          (21, 17, 20, 3, 18, 2),
-                          (22, 18, 19, 4, 21, 2)], self.result.all())
+                          (12,  1, 22, 1, None, node12.tree_id),
+                          (13,  2,  5, 2, 12, node12.tree_id),
+                          (14,  3,  4, 3, 13, node12.tree_id),
+                          (15,  6, 11, 2, 12, node12.tree_id),
+                          (16,  7,  8, 3, 15, node12.tree_id),
+                          (17,  9, 10, 3, 15, node12.tree_id),
+                          (18, 12, 21, 2, 12, node12.tree_id),
+                          (19, 13, 16, 3, 18, node12.tree_id),
+                          (20, 14, 15, 4, 19, node12.tree_id),
+                          (21, 17, 20, 3, 18, node12.tree_id),
+                          (22, 18, 19, 4, 21, node12.tree_id)], self.result.all())
 
     def test_move_to_toplevel_big_subtree(self):
         """ Move node(7) (big subtree) to top level after node(1)
@@ -712,31 +776,37 @@ class MoveAfter(object):
             .filter(self.model.get_pk_column() == 7).one()
         node.parent_id = None
         self.session.add(node)
+        node1 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 1).one()
+        node7 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 7).one()
+        node12 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
         #                 id lft rgt lvl parent tree
-        self.assertEqual([(1,   1, 12, 1, None, 1),
-                          (2,   2,  5, 2,  1, 1),
-                          (3,   3,  4, 3,  2, 1),
-                          (4,   6, 11, 2,  1, 1),
-                          (5,   7,  8, 3,  4, 1),
-                          (6,   9, 10, 3,  4, 1),
+        self.assertEqual([(1,   1, 12, 1, None, node1.tree_id),
+                          (2,   2,  5, 2,  1, node1.tree_id),
+                          (3,   3,  4, 3,  2, node1.tree_id),
+                          (4,   6, 11, 2,  1, node1.tree_id),
+                          (5,   7,  8, 3,  4, node1.tree_id),
+                          (6,   9, 10, 3,  4, node1.tree_id),
 
-                          (7,   1, 10, 1, None, 3),
-                          (8,   2,  5, 2,  7,   3),
-                          (9,   3,  4, 3,  8,   3),
-                          (10,  6,  9, 2,  7,   3),
-                          (11,  7,  8, 3, 10,   3),
+                          (7,   1, 10, 1, None, node7.tree_id),
+                          (8,   2,  5, 2,  7,   node7.tree_id),
+                          (9,   3,  4, 3,  8,   node7.tree_id),
+                          (10,  6,  9, 2,  7,   node7.tree_id),
+                          (11,  7,  8, 3, 10,   node7.tree_id),
 
-                          (12,  1, 22, 1, None, 2),
-                          (13,  2,  5, 2, 12, 2),
-                          (14,  3,  4, 3, 13, 2),
-                          (15,  6, 11, 2, 12, 2),
-                          (16,  7,  8, 3, 15, 2),
-                          (17,  9, 10, 3, 15, 2),
-                          (18, 12, 21, 2, 12, 2),
-                          (19, 13, 16, 3, 18, 2),
-                          (20, 14, 15, 4, 19, 2),
-                          (21, 17, 20, 3, 18, 2),
-                          (22, 18, 19, 4, 21, 2)], self.result.all())
+                          (12,  1, 22, 1, None, node12.tree_id),
+                          (13,  2,  5, 2, 12, node12.tree_id),
+                          (14,  3,  4, 3, 13, node12.tree_id),
+                          (15,  6, 11, 2, 12, node12.tree_id),
+                          (16,  7,  8, 3, 15, node12.tree_id),
+                          (17,  9, 10, 3, 15, node12.tree_id),
+                          (18, 12, 21, 2, 12, node12.tree_id),
+                          (19, 13, 16, 3, 18, node12.tree_id),
+                          (20, 14, 15, 4, 19, node12.tree_id),
+                          (21, 17, 20, 3, 18, node12.tree_id),
+                          (22, 18, 19, 4, 21, node12.tree_id)], self.result.all())
 
     def test_move_after_between_tree(self):
         """ Move node(7) (big subtree) to top level after node(1) and before node(12)
@@ -768,31 +838,37 @@ class MoveAfter(object):
         node = self.session.query(self.model).\
             filter(self.model.get_pk_column() == 7).one()
         node.move_after("1")
+        node1 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 1).one()
+        node7 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 7).one()
+        node12 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
         #                 id lft rgt lvl parent tree
-        self.assertEqual([(1,   1, 12, 1, None, 1),
-                          (2,   2,  5, 2,  1, 1),
-                          (3,   3,  4, 3,  2, 1),
-                          (4,   6, 11, 2,  1, 1),
-                          (5,   7,  8, 3,  4, 1),
-                          (6,   9, 10, 3,  4, 1),
+        self.assertEqual([(1,   1, 12, 1, None, node1.tree_id),
+                          (2,   2,  5, 2,  1, node1.tree_id),
+                          (3,   3,  4, 3,  2, node1.tree_id),
+                          (4,   6, 11, 2,  1, node1.tree_id),
+                          (5,   7,  8, 3,  4, node1.tree_id),
+                          (6,   9, 10, 3,  4, node1.tree_id),
 
-                          (7,   1, 10, 1, None, 2),
-                          (8,   2,  5, 2,  7,   2),
-                          (9,   3,  4, 3,  8,   2),
-                          (10,  6,  9, 2,  7,   2),
-                          (11,  7,  8, 3, 10,   2),
+                          (7,   1, 10, 1, None, node7.tree_id),
+                          (8,   2,  5, 2,  7,   node7.tree_id),
+                          (9,   3,  4, 3,  8,   node7.tree_id),
+                          (10,  6,  9, 2,  7,   node7.tree_id),
+                          (11,  7,  8, 3, 10,   node7.tree_id),
 
-                          (12,  1, 22, 1, None, 3),
-                          (13,  2,  5, 2, 12, 3),
-                          (14,  3,  4, 3, 13, 3),
-                          (15,  6, 11, 2, 12, 3),
-                          (16,  7,  8, 3, 15, 3),
-                          (17,  9, 10, 3, 15, 3),
-                          (18, 12, 21, 2, 12, 3),
-                          (19, 13, 16, 3, 18, 3),
-                          (20, 14, 15, 4, 19, 3),
-                          (21, 17, 20, 3, 18, 3),
-                          (22, 18, 19, 4, 21, 3)], self.result.all())
+                          (12,  1, 22, 1, None, node12.tree_id),
+                          (13,  2,  5, 2, 12, node12.tree_id),
+                          (14,  3,  4, 3, 13, node12.tree_id),
+                          (15,  6, 11, 2, 12, node12.tree_id),
+                          (16,  7,  8, 3, 15, node12.tree_id),
+                          (17,  9, 10, 3, 15, node12.tree_id),
+                          (18, 12, 21, 2, 12, node12.tree_id),
+                          (19, 13, 16, 3, 18, node12.tree_id),
+                          (20, 14, 15, 4, 19, node12.tree_id),
+                          (21, 17, 20, 3, 18, node12.tree_id),
+                          (22, 18, 19, 4, 21, node12.tree_id)], self.result.all())
 
 
 class MoveInside(object):
@@ -829,32 +905,36 @@ class MoveInside(object):
             .filter(self.model.get_pk_column() == 4).one()
         node.parent_id = 15
         self.session.add(node)
+        node1 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 1).one()
+        node12 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
         #                 id lft rgt lvl parent tree
-        self.assertEqual([(1,   1, 16, 1, None, 1),
-                          (2,   2,  5, 2,   1,  1),
-                          (3,   3,  4, 3,   2,  1),
+        self.assertEqual([(1,   1, 16, 1, None, node1.tree_id),
+                          (2,   2,  5, 2,   1,  node1.tree_id),
+                          (3,   3,  4, 3,   2,  node1.tree_id),
 
-                          (4,   7, 12, 3,  15, 2),
-                          (5,   8,  9, 4,   4, 2),
-                          (6,  10, 11, 4,   4, 2),
+                          (4,   7, 12, 3,  15, node12.tree_id),
+                          (5,   8,  9, 4,   4, node12.tree_id),
+                          (6,  10, 11, 4,   4, node12.tree_id),
 
-                          (7,   6, 15, 2,   1,  1),
-                          (8,   7, 10, 3,   7,  1),
-                          (9,   8,  9, 4,   8,  1),
-                          (10, 11, 14, 3,   7,  1),
-                          (11, 12, 13, 4,  10,  1),
+                          (7,   6, 15, 2,   1,  node1.tree_id),
+                          (8,   7, 10, 3,   7,  node1.tree_id),
+                          (9,   8,  9, 4,   8,  node1.tree_id),
+                          (10, 11, 14, 3,   7,  node1.tree_id),
+                          (11, 12, 13, 4,  10,  node1.tree_id),
 
-                          (12,  1, 28, 1, None, 2),
-                          (13,  2,  5, 2, 12, 2),
-                          (14,  3,  4, 3, 13, 2),
-                          (15,  6, 17, 2, 12, 2),
-                          (16, 13, 14, 3, 15, 2),
-                          (17, 15, 16, 3, 15, 2),
-                          (18, 18, 27, 2, 12, 2),
-                          (19, 19, 22, 3, 18, 2),
-                          (20, 20, 21, 4, 19, 2),
-                          (21, 23, 26, 3, 18, 2),
-                          (22, 24, 25, 4, 21, 2)], self.result.all())
+                          (12,  1, 28, 1, None, node12.tree_id),
+                          (13,  2,  5, 2, 12, node12.tree_id),
+                          (14,  3,  4, 3, 13, node12.tree_id),
+                          (15,  6, 17, 2, 12, node12.tree_id),
+                          (16, 13, 14, 3, 15, node12.tree_id),
+                          (17, 15, 16, 3, 15, node12.tree_id),
+                          (18, 18, 27, 2, 12, node12.tree_id),
+                          (19, 19, 22, 3, 18, node12.tree_id),
+                          (20, 20, 21, 4, 19, node12.tree_id),
+                          (21, 23, 26, 3, 18, node12.tree_id),
+                          (22, 24, 25, 4, 21, node12.tree_id)], self.result.all())
 
     def test_move_tree_to_another_tree(self):
         """ Move tree(2) inside tree(1)
@@ -885,28 +965,28 @@ class MoveInside(object):
         node.parent_id = 7
         self.session.add(node)
         #                 id lft rgt lvl parent tree
-        self.assertEqual([(1, 1, 44, 1, None, 1),
-                          (2, 2, 5, 2, 1, 1),
-                          (3, 3, 4, 3, 2, 1),
-                          (4, 6, 11, 2, 1, 1),
-                          (5, 7, 8, 3, 4, 1),
-                          (6, 9, 10, 3, 4, 1),
-                          (7, 12, 43, 2, 1, 1),
-                          (8, 35, 38, 3, 7, 1),
-                          (9, 36, 37, 4, 8, 1),
-                          (10, 39, 42, 3, 7, 1),
-                          (11, 40, 41, 4, 10, 1),
-                          (12, 13, 34, 3, 7, 1),
-                          (13, 14, 17, 4, 12, 1),
-                          (14, 15, 16, 5, 13, 1),
-                          (15, 18, 23, 4, 12, 1),
-                          (16, 19, 20, 5, 15, 1),
-                          (17, 21, 22, 5, 15, 1),
-                          (18, 24, 33, 4, 12, 1),
-                          (19, 25, 28, 5, 18, 1),
-                          (20, 26, 27, 6, 19, 1),
-                          (21, 29, 32, 5, 18, 1),
-                          (22, 30, 31, 6, 21, 1)], self.result.all())
+        self.assertEqual([(1, 1, 44, 1, None, node.tree_id),
+                          (2, 2, 5, 2, 1, node.tree_id),
+                          (3, 3, 4, 3, 2, node.tree_id),
+                          (4, 6, 11, 2, 1, node.tree_id),
+                          (5, 7, 8, 3, 4, node.tree_id),
+                          (6, 9, 10, 3, 4, node.tree_id),
+                          (7, 12, 43, 2, 1, node.tree_id),
+                          (8, 35, 38, 3, 7, node.tree_id),
+                          (9, 36, 37, 4, 8, node.tree_id),
+                          (10, 39, 42, 3, 7, node.tree_id),
+                          (11, 40, 41, 4, 10, node.tree_id),
+                          (12, 13, 34, 3, 7, node.tree_id),
+                          (13, 14, 17, 4, 12, node.tree_id),
+                          (14, 15, 16, 5, 13, node.tree_id),
+                          (15, 18, 23, 4, 12, node.tree_id),
+                          (16, 19, 20, 5, 15, node.tree_id),
+                          (17, 21, 22, 5, 15, node.tree_id),
+                          (18, 24, 33, 4, 12, node.tree_id),
+                          (19, 25, 28, 5, 18, node.tree_id),
+                          (20, 26, 27, 6, 19, node.tree_id),
+                          (21, 29, 32, 5, 18, node.tree_id),
+                          (22, 30, 31, 6, 21, node.tree_id)], self.result.all())
 
     def test_move_inside_function(self):
         """ For example move node(4) inside node(15)
@@ -939,32 +1019,36 @@ class MoveInside(object):
         node = self.session.query(self.model)\
             .filter(self.model.get_pk_column() == 4).one()
         node.move_inside("15")
+        node1 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 1).one()
+        node12 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
         #                 id lft rgt lvl parent tree
-        self.assertEqual([(1,   1, 16, 1, None, 1),
-                          (2,   2,  5, 2,   1,  1),
-                          (3,   3,  4, 3,   2,  1),
+        self.assertEqual([(1,   1, 16, 1, None, node1.tree_id),
+                          (2,   2,  5, 2,   1,  node1.tree_id),
+                          (3,   3,  4, 3,   2,  node1.tree_id),
 
-                          (4,   7, 12, 3,  15, 2),
-                          (5,   8,  9, 4,   4, 2),
-                          (6,  10, 11, 4,   4, 2),
+                          (4,   7, 12, 3,  15, node12.tree_id),
+                          (5,   8,  9, 4,   4, node12.tree_id),
+                          (6,  10, 11, 4,   4, node12.tree_id),
 
-                          (7,   6, 15, 2,   1,  1),
-                          (8,   7, 10, 3,   7,  1),
-                          (9,   8,  9, 4,   8,  1),
-                          (10, 11, 14, 3,   7,  1),
-                          (11, 12, 13, 4,  10,  1),
+                          (7,   6, 15, 2,   1,  node1.tree_id),
+                          (8,   7, 10, 3,   7,  node1.tree_id),
+                          (9,   8,  9, 4,   8,  node1.tree_id),
+                          (10, 11, 14, 3,   7,  node1.tree_id),
+                          (11, 12, 13, 4,  10,  node1.tree_id),
 
-                          (12,  1, 28, 1, None, 2),
-                          (13,  2,  5, 2, 12, 2),
-                          (14,  3,  4, 3, 13, 2),
-                          (15,  6, 17, 2, 12, 2),
-                          (16, 13, 14, 3, 15, 2),
-                          (17, 15, 16, 3, 15, 2),
-                          (18, 18, 27, 2, 12, 2),
-                          (19, 19, 22, 3, 18, 2),
-                          (20, 20, 21, 4, 19, 2),
-                          (21, 23, 26, 3, 18, 2),
-                          (22, 24, 25, 4, 21, 2)], self.result.all())
+                          (12,  1, 28, 1, None, node12.tree_id),
+                          (13,  2,  5, 2, 12, node12.tree_id),
+                          (14,  3,  4, 3, 13, node12.tree_id),
+                          (15,  6, 17, 2, 12, node12.tree_id),
+                          (16, 13, 14, 3, 15, node12.tree_id),
+                          (17, 15, 16, 3, 15, node12.tree_id),
+                          (18, 18, 27, 2, 12, node12.tree_id),
+                          (19, 19, 22, 3, 18, node12.tree_id),
+                          (20, 20, 21, 4, 19, node12.tree_id),
+                          (21, 23, 26, 3, 18, node12.tree_id),
+                          (22, 24, 25, 4, 21, node12.tree_id)], self.result.all())
 
     def test_tree_shorting(self):
         """ Try to move top level node(1) inside tree
@@ -1000,30 +1084,34 @@ class MoveInside(object):
             .filter(self.model.get_pk_column() == 1).one()
         node.parent_id = 11
         self.session.add(node)
+        node1 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 1).one()
+        node12 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
         #                 id lft rgt lvl parent tree
-        self.assertEqual([(1,   1, 22, 1, None, 1),
-                          (2,   2,  5, 2,  1, 1),
-                          (3,   3,  4, 3,  2, 1),
-                          (4,   6, 11, 2,  1, 1),
-                          (5,   7,  8, 3,  4, 1),
-                          (6,   9, 10, 3,  4, 1),
-                          (7,  12, 21, 2,  1, 1),
-                          (8,  13, 16, 3,  7, 1),
-                          (9,  14, 15, 4,  8, 1),
-                          (10, 17, 20, 3,  7, 1),
-                          (11, 18, 19, 4, 10, 1),
+        self.assertEqual([(1,   1, 22, 1, None, node1.tree_id),
+                          (2,   2,  5, 2,  1, node1.tree_id),
+                          (3,   3,  4, 3,  2, node1.tree_id),
+                          (4,   6, 11, 2,  1, node1.tree_id),
+                          (5,   7,  8, 3,  4, node1.tree_id),
+                          (6,   9, 10, 3,  4, node1.tree_id),
+                          (7,  12, 21, 2,  1, node1.tree_id),
+                          (8,  13, 16, 3,  7, node1.tree_id),
+                          (9,  14, 15, 4,  8, node1.tree_id),
+                          (10, 17, 20, 3,  7, node1.tree_id),
+                          (11, 18, 19, 4, 10, node1.tree_id),
 
-                          (12,  1, 22, 1, None, 2),
-                          (13,  2,  5, 2, 12, 2),
-                          (14,  3,  4, 3, 13, 2),
-                          (15,  6, 11, 2, 12, 2),
-                          (16,  7,  8, 3, 15, 2),
-                          (17,  9, 10, 3, 15, 2),
-                          (18, 12, 21, 2, 12, 2),
-                          (19, 13, 16, 3, 18, 2),
-                          (20, 14, 15, 4, 19, 2),
-                          (21, 17, 20, 3, 18, 2),
-                          (22, 18, 19, 4, 21, 2)], self.result.all())
+                          (12,  1, 22, 1, None, node12.tree_id),
+                          (13,  2,  5, 2, 12, node12.tree_id),
+                          (14,  3,  4, 3, 13, node12.tree_id),
+                          (15,  6, 11, 2, 12, node12.tree_id),
+                          (16,  7,  8, 3, 15, node12.tree_id),
+                          (17,  9, 10, 3, 15, node12.tree_id),
+                          (18, 12, 21, 2, 12, node12.tree_id),
+                          (19, 13, 16, 3, 18, node12.tree_id),
+                          (20, 14, 15, 4, 19, node12.tree_id),
+                          (21, 17, 20, 3, 18, node12.tree_id),
+                          (22, 18, 19, 4, 21, node12.tree_id)], self.result.all())
 
     def test_move_inside_to_the_same_parent_function(self):
         """ For example move node(6) inside node(4)
@@ -1056,27 +1144,31 @@ class MoveInside(object):
         node = self.session.query(self.model)\
             .filter(self.model.get_pk_column() == 6).one()
         node.move_inside("4")
+        node1 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 1).one()
+        node12 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
         #                 id lft rgt lvl parent tree
-        self.assertEqual([(1,   1, 22, 1, None, 1),
-                          (2,   2,  5, 2,  1, 1),
-                          (3,   3,  4, 3,  2, 1),
-                          (4,   6, 11, 2,  1, 1),
-                          (5,   9, 10, 3,  4, 1),
-                          (6,   7,  8, 3,  4, 1),
-                          (7,  12, 21, 2,  1, 1),
-                          (8,  13, 16, 3,  7, 1),
-                          (9,  14, 15, 4,  8, 1),
-                          (10, 17, 20, 3,  7, 1),
-                          (11, 18, 19, 4, 10, 1),
+        self.assertEqual([(1,   1, 22, 1, None, node1.tree_id),
+                          (2,   2,  5, 2,  1, node1.tree_id),
+                          (3,   3,  4, 3,  2, node1.tree_id),
+                          (4,   6, 11, 2,  1, node1.tree_id),
+                          (5,   9, 10, 3,  4, node1.tree_id),
+                          (6,   7,  8, 3,  4, node1.tree_id),
+                          (7,  12, 21, 2,  1, node1.tree_id),
+                          (8,  13, 16, 3,  7, node1.tree_id),
+                          (9,  14, 15, 4,  8, node1.tree_id),
+                          (10, 17, 20, 3,  7, node1.tree_id),
+                          (11, 18, 19, 4, 10, node1.tree_id),
 
-                          (12,  1, 22, 1, None, 2),
-                          (13,  2,  5, 2, 12, 2),
-                          (14,  3,  4, 3, 13, 2),
-                          (15,  6, 11, 2, 12, 2),
-                          (16,  7,  8, 3, 15, 2),
-                          (17,  9, 10, 3, 15, 2),
-                          (18, 12, 21, 2, 12, 2),
-                          (19, 13, 16, 3, 18, 2),
-                          (20, 14, 15, 4, 19, 2),
-                          (21, 17, 20, 3, 18, 2),
-                          (22, 18, 19, 4, 21, 2)], self.result.all())
+                          (12,  1, 22, 1, None, node12.tree_id),
+                          (13,  2,  5, 2, 12, node12.tree_id),
+                          (14,  3,  4, 3, 13, node12.tree_id),
+                          (15,  6, 11, 2, 12, node12.tree_id),
+                          (16,  7,  8, 3, 15, node12.tree_id),
+                          (17,  9, 10, 3, 15, node12.tree_id),
+                          (18, 12, 21, 2, 12, node12.tree_id),
+                          (19, 13, 16, 3, 18, node12.tree_id),
+                          (20, 14, 15, 4, 19, node12.tree_id),
+                          (21, 17, 20, 3, 18, node12.tree_id),
+                          (22, 18, 19, 4, 21, node12.tree_id)], self.result.all())

--- a/sqlalchemy_mptt/tests/cases/move_node.py
+++ b/sqlalchemy_mptt/tests/cases/move_node.py
@@ -111,9 +111,12 @@ class MoveBefore(object):
         """
         node2 = self.session.query(self.model)\
             .filter(self.model.get_pk_column() == 12).one()
+        node2.move_before("1")
+
+        node2 = self.session.query(self.model) \
+            .filter(self.model.get_pk_column() == 12).one()
         node1 = self.session.query(self.model) \
             .filter(self.model.get_pk_column() == 1).one()
-        node2.move_before("1")
         #                 id lft rgt lvl parent tree
         self.assertEqual([(1,   1, 22, 1, None, node1.tree_id),
                           (2,   2,  5, 2,  1, node1.tree_id),
@@ -969,29 +972,32 @@ class MoveInside(object):
             filter(self.model.get_pk_column() == 12).one()
         node.parent_id = 7
         self.session.add(node)
+
+        node1 = self.session.query(self.model).\
+            filter(self.model.get_pk_column() == 1).one()
         #                 id lft rgt lvl parent tree
-        self.assertEqual([(1, 1, 44, 1, None, node.tree_id),
-                          (2, 2, 5, 2, 1, node.tree_id),
-                          (3, 3, 4, 3, 2, node.tree_id),
-                          (4, 6, 11, 2, 1, node.tree_id),
-                          (5, 7, 8, 3, 4, node.tree_id),
-                          (6, 9, 10, 3, 4, node.tree_id),
-                          (7, 12, 43, 2, 1, node.tree_id),
-                          (8, 35, 38, 3, 7, node.tree_id),
-                          (9, 36, 37, 4, 8, node.tree_id),
-                          (10, 39, 42, 3, 7, node.tree_id),
-                          (11, 40, 41, 4, 10, node.tree_id),
-                          (12, 13, 34, 3, 7, node.tree_id),
-                          (13, 14, 17, 4, 12, node.tree_id),
-                          (14, 15, 16, 5, 13, node.tree_id),
-                          (15, 18, 23, 4, 12, node.tree_id),
-                          (16, 19, 20, 5, 15, node.tree_id),
-                          (17, 21, 22, 5, 15, node.tree_id),
-                          (18, 24, 33, 4, 12, node.tree_id),
-                          (19, 25, 28, 5, 18, node.tree_id),
-                          (20, 26, 27, 6, 19, node.tree_id),
-                          (21, 29, 32, 5, 18, node.tree_id),
-                          (22, 30, 31, 6, 21, node.tree_id)], self.result.all())
+        self.assertEqual([(1, 1, 44, 1, None, node1.tree_id),
+                          (2, 2, 5, 2, 1, node1.tree_id),
+                          (3, 3, 4, 3, 2, node1.tree_id),
+                          (4, 6, 11, 2, 1, node1.tree_id),
+                          (5, 7, 8, 3, 4, node1.tree_id),
+                          (6, 9, 10, 3, 4, node1.tree_id),
+                          (7, 12, 43, 2, 1, node1.tree_id),
+                          (8, 35, 38, 3, 7, node1.tree_id),
+                          (9, 36, 37, 4, 8, node1.tree_id),
+                          (10, 39, 42, 3, 7, node1.tree_id),
+                          (11, 40, 41, 4, 10, node1.tree_id),
+                          (12, 13, 34, 3, 7, node1.tree_id),
+                          (13, 14, 17, 4, 12, node1.tree_id),
+                          (14, 15, 16, 5, 13, node1.tree_id),
+                          (15, 18, 23, 4, 12, node1.tree_id),
+                          (16, 19, 20, 5, 15, node1.tree_id),
+                          (17, 21, 22, 5, 15, node1.tree_id),
+                          (18, 24, 33, 4, 12, node1.tree_id),
+                          (19, 25, 28, 5, 18, node1.tree_id),
+                          (20, 26, 27, 6, 19, node1.tree_id),
+                          (21, 29, 32, 5, 18, node1.tree_id),
+                          (22, 30, 31, 6, 21, node1.tree_id)], self.result.all())
 
     def test_move_inside_function(self):
         """ For example move node(4) inside node(15)

--- a/sqlalchemy_mptt/tests/test_inheritance.py
+++ b/sqlalchemy_mptt/tests/test_inheritance.py
@@ -57,7 +57,7 @@ class TestTree(unittest.TestCase):
 
         tree = self.session.query(GenericTree).get(1)
         self.assertEqual(tree.ppk, 1)
-        self.assertEqual(tree.tree_id, 1)
+        self.assertEqual(len(tree.tree_id), 32)
 
     def test_create_spec(self):
         self.session.add(SpecializedTree(ppk=1))
@@ -65,7 +65,7 @@ class TestTree(unittest.TestCase):
 
         tree = self.session.query(SpecializedTree).get(1)
         self.assertEqual(tree.ppk, 1)
-        self.assertEqual(tree.tree_id, 1)
+        self.assertEqual(len(tree.tree_id), 32)
 
     def test_create_delete(self):
         parent = SpecializedTree(ppk=1)
@@ -81,7 +81,7 @@ class TestTree(unittest.TestCase):
 
         tree = self.session.query(SpecializedTree).get(1)
         self.assertEqual(tree.ppk, 1)
-        self.assertEqual(tree.tree_id, 1)
+        self.assertEqual(len(tree.tree_id), 32)
 
         self.session.delete(child1)
         self.session.commit()

--- a/sqlalchemy_mptt/tests/test_inheritance.py
+++ b/sqlalchemy_mptt/tests/test_inheritance.py
@@ -57,7 +57,7 @@ class TestTree(unittest.TestCase):
 
         tree = self.session.query(GenericTree).get(1)
         self.assertEqual(tree.ppk, 1)
-        self.assertEqual(len(tree.tree_id), 32)
+        self.assertGreaterEqual(len(tree.tree_id), 32)
 
     def test_create_spec(self):
         self.session.add(SpecializedTree(ppk=1))
@@ -65,7 +65,7 @@ class TestTree(unittest.TestCase):
 
         tree = self.session.query(SpecializedTree).get(1)
         self.assertEqual(tree.ppk, 1)
-        self.assertEqual(len(tree.tree_id), 32)
+        self.assertGreaterEqual(len(tree.tree_id), 32)
 
     def test_create_delete(self):
         parent = SpecializedTree(ppk=1)
@@ -81,7 +81,7 @@ class TestTree(unittest.TestCase):
 
         tree = self.session.query(SpecializedTree).get(1)
         self.assertEqual(tree.ppk, 1)
-        self.assertEqual(len(tree.tree_id), 32)
+        self.assertGreaterEqual(len(tree.tree_id), 32)
 
         self.session.delete(child1)
         self.session.commit()


### PR DESCRIPTION
The `tree_id` column is currently an Integer thats managed in application code.  New trees are created by querying for the max value in the table and incrementing it by one, which isn't thread safe.  An an example, a multithreaded application may try to create two different new trees and assign them both the same tree_id.  I've made the tree_id a `Unicode(32)` so that tree IDs can be generated as GUIDs in application code without the risk of ID collisions.

I like the lib a lot!
