### PR TITLE
Improve docs on setup

### DIFF
--- a/docs/initialize.rst
+++ b/docs/initialize.rst
@@ -25,8 +25,8 @@ Create model with MPTT mixin:
 
 
 
-Session
--------
+Session factory wrapper
+-----------------------
 
 For the automatic tree maintainance triggered after session flush to work
 correctly, wrap the Session factory with :mod:`sqlalchemy_mptt.mptt_sessionmaker`
@@ -40,6 +40,35 @@ correctly, wrap the Session factory with :mod:`sqlalchemy_mptt.mptt_sessionmaker
 
     engine = create_engine('...')
     Session = mptt_sessionmaker(sessionmaker(bind=engine))
+
+Using session factory wrapper with flask_sqlalchemy
+---------------------------------------------------
+
+If you use Flask and SQLAlchemy, you probably use also flask_sqlalchemy
+extension for integration. In that case the Session creation is not directly
+accessible. The following allows you to use the wrapper:
+
+.. code-block:: python
+    :linenos:
+
+    from sqlalchemy_mptt import mptt_sessionmaker
+    from flask_sqlalchemy import SQLAlchemy
+
+    # instead of creating db object directly
+    db = SQLAlchemy()
+
+    # subclass the db manager and insert the wrapper at session creation
+    class CustomSQLAlchemy(SQLAlchemy):
+        """A custom SQLAlchemy manager, to have control on session creation"""
+
+        def create_session(self, options):
+            """Override the original session factory creation"""
+            Session = super().create_session(options)
+            # Use wrapper from sqlalchemy_mptt that manage tree tables
+            return mptt_sessionmaker(Session)
+
+    # then
+    db = CustomSQLAlchemy()
 
 
 Events

--- a/docs/initialize.rst
+++ b/docs/initialize.rst
@@ -78,14 +78,15 @@ Represented data of tree like dict
         {'id': '11',                  'parent_id': '10'},
     )
 
-Filling data at the first time
-------------------------------
+Initializing a tree with data
+-----------------------------
 
-When you add any data to the database, he tries to be counted lft,
-rgt and level attribute. This is done very quickly if the tree already
-exists in the database, but it is absolutely not allowed for initialize
-the tree, it is very long. In this case, you can change the code like
-this:
+When you add nodes to the table, the tree manager subsequently updates the
+level, left and right attributes in the reset of the table. This is done very
+quickly if the tree already exists in the database, but for initializing the
+tree, it might become a big overhead. In this case, it is recommended to
+deactivate automatic tree management, fill in the data, reactivate automatic
+tree management and finally call manually a rebuild of the tree once at the end:
 
 .. no-code-block:: python
 

--- a/docs/initialize.rst
+++ b/docs/initialize.rst
@@ -113,8 +113,8 @@ After an initial table with tree you can use mptt features.
 Session
 -------
 
-To work correctly after flush you should use
-:mod:`sqlalchemy_mptt.mptt_sessionmaker`
+For the automatic tree maintainance triggered after session flush to work
+correctly, wrap the Session factory with :mod:`sqlalchemy_mptt.mptt_sessionmaker`
 
 .. code-block:: python
     :linenos:

--- a/docs/initialize.rst
+++ b/docs/initialize.rst
@@ -24,12 +24,28 @@ Create model with MPTT mixin:
             return "<Node (%s)>" % self.id
 
 
-It automatically registers events.
+
+Session
+-------
+
+For the automatic tree maintainance triggered after session flush to work
+correctly, wrap the Session factory with :mod:`sqlalchemy_mptt.mptt_sessionmaker`
+
+.. code-block:: python
+    :linenos:
+
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from sqlalchemy_mptt import mptt_sessionmaker
+
+    engine = create_engine('...')
+    Session = mptt_sessionmaker(sessionmaker(bind=engine))
+
 
 Events
 ------
 
-But you can do it manually:
+The tree manager automatically registers events. But you can do it manually:
 
 .. code-block:: python
 
@@ -77,7 +93,6 @@ Represented data of tree like dict
         {'id': '10',                  'parent_id':  '7'},
         {'id': '11',                  'parent_id': '10'},
     )
-
 Initializing a tree with data
 -----------------------------
 
@@ -110,19 +125,3 @@ tree management and finally call manually a rebuild of the tree once at the end:
     models.MyModelTree.rebuild_tree(db.session, 'my_tree_1') # rebuild lft, rgt value automatically
 
 After an initial table with tree you can use mptt features.
-
-Session
--------
-
-For the automatic tree maintainance triggered after session flush to work
-correctly, wrap the Session factory with :mod:`sqlalchemy_mptt.mptt_sessionmaker`
-
-.. code-block:: python
-    :linenos:
-
-    from sqlalchemy import create_engine
-    from sqlalchemy.orm import sessionmaker
-    from sqlalchemy_mptt import mptt_sessionmaker
-
-    engine = create_engine('...')
-    Session = mptt_sessionmaker(sessionmaker(bind=engine))


### PR DESCRIPTION
I spent a lot of time the last two days trying to understand why the tree was not updated correctly after flush, before finding and understanding the paragraph on the `mptt_sessionmaker`. I changed the docs to make it clearer that this step is mandatory. I also struggled to find out where to apply this wrapper, because we use flask_sqlalchemy for integration with our flask backend, and the Session creation is hidden. So I add also instructions on how to apply `mptt_sessionmaker` in that case.