### PR TITLE
Allow to specify ordering of path_to_root

### DIFF
--- a/sqlalchemy_mptt/mixins.py
+++ b/sqlalchemy_mptt/mixins.py
@@ -336,7 +336,7 @@ class BaseNestedSets(object):
             query=self._drilldown_query
         )
 
-    def path_to_root(self, session=None):
+    def path_to_root(self, session=None, order=desc):
         """Generate path from a leaf or intermediate node to the root.
 
         For example:
@@ -364,7 +364,7 @@ class BaseNestedSets(object):
         table = self.__class__
         query = self._base_query_obj(session=session)
         query = query.filter(table.is_ancestor_of(self, inclusive=True))
-        return self._base_order(query, order=desc)
+        return self._base_order(query, order=order)
 
     @classmethod
     def rebuild_tree(cls, session, tree_id):

--- a/sqlalchemy_mptt/tests/cases/get_tree.py
+++ b/sqlalchemy_mptt/tests/cases/get_tree.py
@@ -1,3 +1,6 @@
+from sqlalchemy import asc
+
+
 def get_obj(session, model, id):
     return session.query(model).filter(model.get_pk_column() == id).one()
 
@@ -317,3 +320,6 @@ class Tree(object):
         self.assertEqual(path_8_to_root, [go(8), go(7), go(1)])
         self.assertEqual(path_6_to_root, [go(6), go(4), go(1)])
         self.assertEqual(path_1_to_root, [go(1)])
+
+        asc_path_11_to_root = node11.path_to_root(self.session, order=asc).all()
+        self.assertEqual(asc_path_11_to_root, [go(1), go(7), go(10), go(11)])


### PR DESCRIPTION
Useful to generate a breadcrumb e.g:

```
/root/child/grand-child
```