### PR TITLE
docs: Fix a few typos

### DIFF
--- a/sqlalchemy_mptt/events.py
+++ b/sqlalchemy_mptt/events.py
@@ -532,7 +532,7 @@ class TreesManager(object):
         Registers this TreesManager instance to respond on
         `after_flush_postexec` events on the given session or session factory.
         This method returns the original argument, so that it can be used by
-        wrapping an already exisiting instance:
+        wrapping an already existing instance:
 
         .. code-block:: python
             :linenos:

--- a/sqlalchemy_mptt/mixins.py
+++ b/sqlalchemy_mptt/mixins.py
@@ -285,7 +285,7 @@ class BaseNestedSets(object):
         for node in nodes:
             result = cls._node_to_dict(node, json, json_fields)
             parent_id = node.parent_id
-            if node.level != min_level:  # for cildren
+            if node.level != min_level:  # for children
                 # Find parent in the tree
                 if parent_id not in nodes_of_level.keys():
                     continue
@@ -307,7 +307,7 @@ class BaseNestedSets(object):
         return nodes.filter(self.is_ancestor_of(table, inclusive=True))
 
     def drilldown_tree(self, session=None, json=False, json_fields=None):
-        """ This method generate a branch from a tree, begining with current
+        """ This method generate a branch from a tree, beginning with current
         node.
 
         For example:


### PR DESCRIPTION
There are small typos in:
- sqlalchemy_mptt/events.py
- sqlalchemy_mptt/mixins.py

Fixes:
- Should read `existing` rather than `exisiting`.
- Should read `children` rather than `cildren`.
- Should read `beginning` rather than `begining`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md