### PR TITLE
Add index to foreign key (parent_id) column for optimized record retrieval & deletion

### DIFF
--- a/sqlalchemy_mptt/mixins.py
+++ b/sqlalchemy_mptt/mixins.py
@@ -86,6 +86,7 @@ class BaseNestedSets(object):
             ForeignKey(
                 "{}.{}".format(cls.__tablename__, pk.name), ondelete="CASCADE"
             ),
+            index=True
         )
 
     @declared_attr


### PR DESCRIPTION
The problem was identified in the foreign key(parent_id) column, where retrieval and deletion of records took an unexpectedly long time. To optimize the retrieval and deletion process, this fix introduces a new index on the relevant foreign key (parent_id) column.

This commit addresses performance issues related to both record deletion and retrieval in the sqlalchemy_mptt library. Adding an index to the foreign key(parent_id) column improves the efficiency of both operations, significantly reducing the time taken for deletion and retrieval.