### PR TITLE
Optimize stateful test healthcheck

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -121,7 +121,8 @@ def test(session, sqlalchemy):
         with_coverage = True
     pytest_cmd = [
         "pytest", "--pyargs", "sqlalchemy_mptt",
-        "--cov", "sqlalchemy_mptt", "--cov-report", "term-missing:skip-covered"
+        "--cov", "sqlalchemy_mptt", "--cov-report", "term-missing:skip-covered",
+        "-W", "error:::sqlalchemy_mptt"
     ] + (["--cov-report", "xml"] if with_coverage else []) + session.posargs
     session.run(*pytest_cmd)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -122,7 +122,7 @@ def test(session, sqlalchemy):
     pytest_cmd = [
         "pytest", "--pyargs", "sqlalchemy_mptt",
         "--cov", "sqlalchemy_mptt", "--cov-report", "term-missing:skip-covered"
-    ] + ["--cov-report", "xml"] if with_coverage else [] + session.posargs
+    ] + (["--cov-report", "xml"] if with_coverage else []) + session.posargs
     session.run(*pytest_cmd)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -119,11 +119,13 @@ def test(session, sqlalchemy):
         with_coverage = False
     else:
         with_coverage = True
-    pytest_cmd = [
-        "pytest", "--pyargs", "sqlalchemy_mptt",
-        "--cov", "sqlalchemy_mptt", "--cov-report", "term-missing:skip-covered",
-        "-W", "error:::sqlalchemy_mptt"
-    ] + (["--cov-report", "xml"] if with_coverage else []) + session.posargs
+    pytest_cmd = ["pytest"] + (
+        session.posargs or [
+            "--pyargs", "sqlalchemy_mptt",
+            "--cov", "sqlalchemy_mptt", "--cov-report", "term-missing:skip-covered",
+            "-W", "error:::sqlalchemy_mptt"
+        ]
+    ) + (["--cov-report", "xml"] if with_coverage else [])
     session.run(*pytest_cmd)
 
 

--- a/sqlalchemy_mptt/tests/test_stateful.py
+++ b/sqlalchemy_mptt/tests/test_stateful.py
@@ -3,7 +3,7 @@ from hypothesis import assume, given, settings, strategies as st
 from hypothesis.stateful import Bundle, RuleBasedStateMachine, consumes, invariant, rule
 from sqlalchemy import Column, Integer, Boolean, create_engine
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker, was_deleted
+from sqlalchemy.orm import sessionmaker
 
 from sqlalchemy_mptt import BaseNestedSets, mptt_sessionmaker
 

--- a/sqlalchemy_mptt/tests/test_stateful.py
+++ b/sqlalchemy_mptt/tests/test_stateful.py
@@ -116,5 +116,5 @@ def validate_get_tree_node_for_custom_query(node_response):
 # Export the stateful test case
 TestTreeStates = TreeStateMachine.TestCase
 TestTreeStates.settings = settings(
-    max_examples=75, stateful_step_count=25#, suppress_health_check=[HealthCheck.too_slow]
+    max_examples=75, stateful_step_count=25, suppress_health_check=[HealthCheck.too_slow]
 )

--- a/sqlalchemy_mptt/tests/test_stateful.py
+++ b/sqlalchemy_mptt/tests/test_stateful.py
@@ -1,3 +1,9 @@
+# -*- coding: utf-8 -*-
+# vim:fenc=utf-8
+#
+# Copyright © 2025 fayazkhan <fayaz.yusuf.khan@gmail.com>
+#
+# Distributed under terms of the MIT license.
 """Test cases written using Hypothesis stateful testing framework."""
 from hypothesis import HealthCheck, settings, strategies as st
 from hypothesis.stateful import Bundle, RuleBasedStateMachine, consumes, invariant, rule
@@ -110,5 +116,5 @@ def validate_get_tree_node_for_custom_query(node_response):
 # Export the stateful test case
 TestTreeStates = TreeStateMachine.TestCase
 TestTreeStates.settings = settings(
-    max_examples=75, stateful_step_count=25, suppress_health_check=[HealthCheck.too_slow]
+    max_examples=75, stateful_step_count=25#, suppress_health_check=[HealthCheck.too_slow]
 )

--- a/sqlalchemy_mptt/tests/test_stateful.py
+++ b/sqlalchemy_mptt/tests/test_stateful.py
@@ -109,5 +109,5 @@ def validate_get_tree_node_for_custom_query(node_response):
 # Export the stateful test case
 TestTreeStates = TreeStateMachine.TestCase
 TestTreeStates.settings = settings(
-    max_examples=75, stateful_step_count=25
+    max_examples=75, stateful_step_count=25, suppress_health_check=[HealthCheck.too_slow]
 )

--- a/sqlalchemy_mptt/tests/test_stateful.py
+++ b/sqlalchemy_mptt/tests/test_stateful.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim:fenc=utf-8
 #
-# Copyright © 2025 fayazkhan <fayaz.yusuf.khan@gmail.com>
+# Copyright (c) 2025 Fayaz Yusuf Khan <fayaz.yusuf.khan@gmail.com>
 #
 # Distributed under terms of the MIT license.
 """Test cases written using Hypothesis stateful testing framework."""


### PR DESCRIPTION
* Disable `too_slow` health check for slower pypy runtimes.
* Eagerly remove children from the bundle when deleting ancestors.
* Improve command line args handling for tests.